### PR TITLE
Fix Correct item names in update modal for marriage declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 - Use image tag instead of patterns in certificate SVGs
 - Generate default address according to logged-in user's location
 - Remove authentication from dashboard queries route
-- Added french translation of informant for print certificate flow, issue certificate flow & correction flow 
+- Added french translation of informant for print certificate flow, issue certificate flow & correction flow
+- Groom's and Bride's name, printIssue translation variables updated [#124](https://github.com/opencrvs/opencrvs-countryconfig/pull/124)
 
 ## [1.4.1](https://github.com/opencrvs/opencrvs-countryconfig/compare/v1.4.0...v1.4.1)
 

--- a/src/form/marriage/index.ts
+++ b/src/form/marriage/index.ts
@@ -84,7 +84,7 @@ export const marriageForm: ISerializedForm = {
     {
       id: 'informant',
       viewType: 'form',
-      name: formMessageDescriptors.registrationName,
+      name: formMessageDescriptors.informantName,
       title: formMessageDescriptors.informantTitle,
       groups: [
         {

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -903,7 +903,9 @@ form.field.label.ageOfGroom,,Age of groom,Âge du marié
 form.field.label.ageOfInformant,,Age of informant,Âge de l'informateur
 form.field.label.ageOfMother,,Age of mother,Âge de la mère
 form.field.label.ageOfSpouse,,Age of spouse,Âge du conjoint
+form.field.label.app.certifyRecordTo.bride,,Print and issue to bride,Imprimer et envoyer à la mariée
 form.field.label.app.certifyRecordTo.father,,Print and issue to father,Imprimer et remettre au père
+form.field.label.app.certifyRecordTo.groom,,Print and issue to groom,Imprimer et envoyer au marié
 form.field.label.app.certifyRecordTo.informant,,"Print and issue to informant ({informant, select, MOTHER {Mother} FATHER {Father} GRANDFATHER {Grandfather} GRANDMOTHER {Grandmother} BROTHER {Brother} SISTER {Sister} LEGAL_GUARDIAN {Legal guardian} BRIDE {Bride} GROOM {Groom} HEAD_OF_GROOM_FAMILY {Head of groom's family} HEAD_OF_BRIDE_FAMILY {Head of bride's family} SPOUSE {Spouse} SON {Son} DAUGHTER {Daughter} SON_IN_LAW {Son in law} DAUGHTER_IN_LAW {Daughter in law} GRANDSON {Grandson} GRANDDAUGHTER {Granddaughter} other {{informant}}})","Imprimer et remettre à l'informateur ({informant, select, MOTHER {Mère} FATHER {Père} GRANDFATHER {Grand-père} GRANDMOTHER {Grand-mère} BROTHER {Frère} SISTER {Sœur} LEGAL_GUARDIAN {Tuteur légal} BRIDE {Mariée} GROOM {Marié} HEAD_OF_GROOM_FAMILY {Chef de la famille du marié} HEAD_OF_BRIDE_FAMILY {Chef de la famille de la mariée} SPOUSE {Conjoint} SON {Fils} DAUGHTER {Fille} SON_IN_LAW {Beau-fils} DAUGHTER_IN_LAW {Belle-fille} GRANDSON {Petit-fils} GRANDDAUGHTER {Petite-fille} other {{informant}}})"
 form.field.label.app.certifyRecordTo.mother,,Print and issue to mother,Imprimer et remettre à la mère
 form.field.label.app.phoneVerWarn,,Check with the informant that the mobile phone number you have entered is correct,Vérifiez auprès de l'informateur que le numéro de téléphone mobile que vous avez indiqué est correct.
@@ -1290,7 +1292,7 @@ form.section.accountDetails,,Account details,Coordonnées du compte
 form.section.assignedRegistrationOffice,,Assign to a registration office,A quel bureau voulez-vous affecter un nouvel utilisateur ?
 form.section.assignedRegistrationOfficeGroupTitle,,Assigned registration office,Bureau d'enregistrement assigné
 form.section.bride.headOfBrideFamily,,Head of bride's family,Chef de la famille de la mariée
-form.section.bride.name,,Print and issue to bride,Imprimer et envoyer à la mariée
+form.section.bride.name,,Bride,Mariée
 form.section.bride.title,,Bride's details,Détails de la mariée
 form.section.causeOfDeath.name,,Cause of Death,Cause du décès
 form.section.causeOfDeath.title,,What is the medically certified cause of death?,Quelle est la cause de décès médicalement certifiée ?
@@ -1327,7 +1329,7 @@ form.section.documents.uploadImage,,Upload a photo of the supporting document,T�
 form.section.father.name,,Father,Père
 form.section.father.title,,Father's details,Information du père
 form.section.groom.headOfGroomFamily,,Head of groom's family,Chef de la famille du marié
-form.section.groom.name,,Print and issue to groom,Imprimer et envoyer au marié
+form.section.groom.name,,Groom,Marié
 form.section.groom.title,,Groom's details,Détails du marié
 form.section.informant.name,,Informant,Informateur
 form.section.informant.title,,Informant's details,information de l'informateur


### PR DESCRIPTION
Updated the item names in the update modal for marriage declarations to:
- 'Informant' in place of 'Registration name'
- 'Bride' in place of 'Print and issue to bride'
- 'Groom' in place of 'Print and issue to Groom'

related core pull request: https://github.com/opencrvs/opencrvs-core/pull/7066