### PR TITLE
Update setup-environment.ts & deploy.sh to support non-default SSH port

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -143,6 +143,7 @@ jobs:
           --environment=${{ github.event.inputs.environment }} \
           --host=${{ vars.DOMAIN }} \
           --ssh_host=${{ secrets.SSH_HOST }} \
+          --ssh_port=${{ secrets.SSH_PORT }} \
           --ssh_user=${{ secrets.SSH_USER }} \
           --version=${{ github.event.inputs.core-image-tag }} \
           --country_config_version=${{ github.event.inputs.countryconfig-image-tag }} \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,6 +147,7 @@ jobs:
           --environment=${{ github.event.inputs.environment }} \
           --host=${{ vars.DOMAIN }} \
           --ssh_host=${{ secrets.SSH_HOST }} \
+          --ssh_port=${{ secrets.SSH_PORT }} \
           --ssh_user=${{ secrets.SSH_USER }} \
           --version=${{ github.event.inputs.core-image-tag }} \
           --country_config_version=${{ github.event.inputs.countryconfig-image-tag }} \

--- a/infrastructure/deployment/deploy.sh
+++ b/infrastructure/deployment/deploy.sh
@@ -89,7 +89,7 @@ function trapint {
 }
 
 print_usage_and_exit () {
-  echo 'Usage: ./deploy.sh --host --environment --ssh_host --ssh_user --version --country_config_version --replicas'
+  echo 'Usage: ./deploy.sh --host --environment --ssh_host --ssh_port --ssh_user --version --country_config_version --replicas'
   echo "  --environment can be 'production', 'development', 'qa' or similar"
   echo '  --host    is the server to deploy to'
   echo "  --version can be any OpenCRVS Core docker image tag or 'latest'"

--- a/infrastructure/deployment/deploy.sh
+++ b/infrastructure/deployment/deploy.sh
@@ -119,6 +119,11 @@ validate_options() {
     print_usage_and_exit
   fi
 
+  if [ -z "$SSH_PORT" ] ; then
+    echo 'Error: Argument --ssh_port is required.'
+    print_usage_and_exit
+  fi
+
   if [ -z "$SSH_USER" ] ; then
     echo 'Error: Argument --ssh_user is required.'
     print_usage_and_exit

--- a/infrastructure/deployment/deploy.sh
+++ b/infrastructure/deployment/deploy.sh
@@ -63,7 +63,6 @@ done
 
 
 # Default values
-SSH_PORT=22
 SSH_ARGS=${SSH_ARGS:-""}
 LOG_LOCATION=${LOG_LOCATION:-/var/log}
 

--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -316,7 +316,7 @@ const sshQuestions = [
     name: 'sshPort',
     type: 'number' as const,
     message:
-      'What port number is used in establishing the SSH connection? This usually is the standard 22. If you are an advanced user, and have set a different port, provide it here.',
+      'What port number is used in establishing the SSH connection? This usually is the default 22. If you are an advanced user, and have set a different port, provide it here.',
     valueType: 'SECRET' as const,
     validate: notEmpty,
     valueLabel: 'SSH_PORT',

--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -313,6 +313,17 @@ const sshQuestions = [
     scope: 'ENVIRONMENT' as const
   },
   {
+    name: 'sshPort',
+    type: 'number' as const,
+    message:
+      'What port number is used in establishing the SSH connection? This usually is the standard 22. If you are an advanced user, and have set a different port, provide it here.',
+    valueType: 'SECRET' as const,
+    validate: notEmpty,
+    valueLabel: 'SSH_PORT',
+    initial: process.env.SSH_PORT ? parseInt(process.env.SSH_PORT) : 22,
+    scope: 'ENVIRONMENT' as const
+  },
+  {
     name: 'sshArgs',
     type: 'text' as const,
     message:


### PR DESCRIPTION
Closes: https://github.com/opencrvs/opencrvs-core/issues/7018

- Allow only numbers in user input / setup-environment.ts
- Reasonable instructions given to use default port 22 unless user is advanced and configured to use some other port than 22
- Manually tested the yarn environment:init cli tool, it logged the right port (22 or 77 depending on input) to terminal, added it to .env.{env} and to a GitHub repo correctly