### PR TITLE
Trivvy scan

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -39,6 +39,15 @@ jobs:
           DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_REPO }}
         run: |
           # Check if the current commit has a tag and use it; otherwise, use the short SHA of the HEAD commit
-          export COUNTRY_CONFIG_VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short=7 HEAD)
+          echo "COUNTRY_CONFIG_VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
           echo "Publishing a Docker image with a tag $COUNTRY_CONFIG_VERSION"
-          bash build-and-push.sh && unset COUNTRY_CONFIG_VERSION
+          docker compose build
+          docker compose push
+      - name: Run Trivy scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          sparse-checkout: |
+            trivy.yaml
+          sparse-checkout-cone-mode: false
+          image-ref: '${{ secrets.DOCKERHUB_ACCOUNT }}/${{ secrets.DOCKERHUB_REPO }}:$COUNTRY_CONFIG_VERSION'
+          trivy-config: trivy.yaml

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -39,7 +39,8 @@ jobs:
           DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_REPO }}
         run: |
           # Check if the current commit has a tag and use it; otherwise, use the short SHA of the HEAD commit
-          export "COUNTRY_CONFIG_VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+          export "COUNTRY_CONFIG_VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short=7 HEAD)"
+          echo "COUNTRY_CONFIG_VERSION=$COUNTRY_CONFIG_VERSION" >> $GITHUB_ENV
           echo "Publishing a Docker image with a tag $COUNTRY_CONFIG_VERSION"
           docker compose build
           docker compose push

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -49,5 +49,5 @@ jobs:
           sparse-checkout: |
             trivy.yaml
           sparse-checkout-cone-mode: false
-          image-ref: '${{ secrets.DOCKERHUB_ACCOUNT }}/${{ secrets.DOCKERHUB_REPO }}:$COUNTRY_CONFIG_VERSION'
+          image-ref: '${{ secrets.DOCKERHUB_ACCOUNT }}/${{ secrets.DOCKERHUB_REPO }}:${{ env.COUNTRY_CONFIG_VERSION }}'
           trivy-config: trivy.yaml

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -39,7 +39,7 @@ jobs:
           DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_REPO }}
         run: |
           # Check if the current commit has a tag and use it; otherwise, use the short SHA of the HEAD commit
-          echo "COUNTRY_CONFIG_VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+          export "COUNTRY_CONFIG_VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
           echo "Publishing a Docker image with a tag $COUNTRY_CONFIG_VERSION"
           docker compose build
           docker compose push

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           sparse-checkout: |
             trivy.yaml
+            .trivyignore.yaml
           sparse-checkout-cone-mode: false
           image-ref: '${{ secrets.DOCKERHUB_ACCOUNT }}/${{ secrets.DOCKERHUB_REPO }}:${{ env.COUNTRY_CONFIG_VERSION }}'
           trivy-config: trivy.yaml

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+misconfigurations:
+  - id: AVD-DS-0002
+    statement: Ignore yarn cache and Dockerfile
+    paths:
+      - 'Dockerfile'
+      - '/usr/local/share/.cache'

--- a/trivy.yml
+++ b/trivy.yml
@@ -1,4 +1,3 @@
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,7 +6,17 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-set -e
-
-docker compose build
-docker compose push
+exit-code: 1
+severity:
+  - HIGH
+  - CRITICAL
+scan:
+  skip-dirs:
+    - node_modules
+    - usr/local/share/.cache/yarn/v6/
+  scanners:
+    - vuln
+    - misconfig
+    - secret
+vulnerability:
+  ignore-unfixed: true


### PR DESCRIPTION
@rikukissa what do you think of adding Trivy scan to countryconfig?  Not sure I have configured the .trivyignore correctly

Example run: https://github.com/opencrvs/opencrvs-countryconfig/actions/runs/9503686481/job/26194680803

Errors not thrown, but there's a lot of output:

![Screenshot 2024-06-13 at 18 04 53](https://github.com/opencrvs/opencrvs-countryconfig/assets/3169954/92fe10cc-cc34-4974-8a54-c8e0f8a5e852)


TODO:

- [ ] Fix .trivyignore to ignore yarn cache
- [ ] Apply to publish release workflow