### PR TITLE
Ignore baseimage when deploying

### DIFF
--- a/infrastructure/deployment/deploy.sh
+++ b/infrastructure/deployment/deploy.sh
@@ -220,6 +220,8 @@ get_docker_tags_from_compose_files() {
    IMAGE_TAG_LIST=$(cat $SPACE_SEPARATED_COMPOSE_FILE_LIST \
    `# Select rows with the image tag` \
    | grep image: \
+   `# Ignore the baseimage file as its not used directly` \
+   | grep -v ocrvs-base \
    `# Only keep the image version` \
    | sed "s/image://")
 


### PR DESCRIPTION
In https://github.com/opencrvs/opencrvs-core/pull/6919 we add a new baseimage that is part of compose for convenience of builds. But during deploys we should always skip this