### PR TITLE
fix(ocrvs-5086): show different label when father address matches

### DIFF
--- a/src/form/addresses/address-fields.ts
+++ b/src/form/addresses/address-fields.ts
@@ -3,6 +3,7 @@ import {
   AddressCases,
   AddressCopyConfigCases,
   AddressSubsections,
+  Conditional,
   EventLocationAddressCases,
   SerializedFormField
 } from '../types/types'
@@ -18,13 +19,14 @@ import { yesNoRadioOptions } from '../common/select-options'
 import { ADMIN_LEVELS } from '.'
 import { getPlaceOfBirthFields } from '../birth/required-fields'
 import { getPlaceOfDeathFields } from '../death/required-fields'
+import { expressionToConditional } from '../common/default-validation-conditionals'
 
 // A radio group field that allows you to select an address from another section
 export const getXAddressSameAsY = (
   xComparisonSection: string,
   yComparisonSection: string,
   label: MessageDescriptor,
-  conditionalCase?: string
+  conditionals?: Conditional[] | string
 ): SerializedFormField[] => {
   const copyAddressField: SerializedFormField = {
     name: AddressCopyConfigCases.PRIMARY_ADDRESS_SAME_AS_OTHER_PRIMARY,
@@ -32,16 +34,12 @@ export const getXAddressSameAsY = (
     label,
     required: true,
     initialValue: true,
-    previewGroup: AddressSubsections.PRIMARY_ADDRESS_SUBSECTION,
     validator: [],
     options: yesNoRadioOptions,
-    conditionals: conditionalCase
-      ? [
-          {
-            action: 'hide',
-            expression: `${conditionalCase}`
-          }
-        ]
+    conditionals: conditionals
+      ? typeof conditionals === 'string'
+        ? [expressionToConditional(conditionals)]
+        : conditionals
       : [],
     mapping: {
       mutation: {

--- a/src/form/addresses/index.ts
+++ b/src/form/addresses/index.ts
@@ -191,14 +191,28 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
       {
         config: AddressCopyConfigCases.PRIMARY_ADDRESS_SAME_AS_OTHER_PRIMARY,
         label: formMessageDescriptors.primaryAddressSameAsDeceasedsPrimary,
-        conditionalCase: `${isInformantSpouse}`,
+        conditionalCase: [
+          expressionToConditional(isInformantSpouse),
+          expressionToConditional(
+            `${isInformantSpouse} || !${primaryAddressSameAsOtherPrimaryAddress}`,
+            'hideInPreview'
+          )
+        ],
         xComparisonSection: 'informant',
         yComparisonSection: 'deceased'
       },
       {
         config: AddressSubsections.PRIMARY_ADDRESS_SUBSECTION,
         label: formMessageDescriptors.informantPrimaryAddress,
-        conditionalCase: `${primaryAddressSameAsOtherPrimaryAddress} || ${hideIfInformantSpouse[0].expression}`
+        conditionalCase: [
+          expressionToConditional(
+            `${primaryAddressSameAsOtherPrimaryAddress} || ${hideIfInformantSpouse[0].expression}`
+          ),
+          expressionToConditional(
+            `${primaryAddressSameAsOtherPrimaryAddress} || ${hideIfInformantSpouse[0].expression} || ${primaryAddressSameAsOtherPrimaryAddress}`,
+            'hideInPreview'
+          )
+        ]
       },
       {
         config: AddressCases.PRIMARY_ADDRESS,
@@ -257,14 +271,26 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
       {
         config: AddressSubsections.PRIMARY_ADDRESS_SUBSECTION,
         label: formMessageDescriptors.primaryAddress,
-        conditionalCase: `${SPOUSE_DETAILS_DONT_EXIST}`
+        conditionalCase: [
+          expressionToConditional(SPOUSE_DETAILS_DONT_EXIST),
+          expressionToConditional(
+            `${SPOUSE_DETAILS_DONT_EXIST} || ${primaryAddressSameAsOtherPrimaryAddress}`,
+            'hideInPreview'
+          )
+        ]
       },
       {
         config: AddressCopyConfigCases.PRIMARY_ADDRESS_SAME_AS_OTHER_PRIMARY,
         label: formMessageDescriptors.primaryAddressSameAsDeceasedsPrimary,
         xComparisonSection: 'spouse',
         yComparisonSection: 'deceased',
-        conditionalCase: `${detailsDontExist}`
+        conditionalCase: [
+          expressionToConditional(detailsDontExist),
+          expressionToConditional(
+            `${detailsDontExist} || !${primaryAddressSameAsOtherPrimaryAddress}`,
+            'hideInPreview'
+          )
+        ]
       },
       {
         config: AddressCases.PRIMARY_ADDRESS,

--- a/src/form/addresses/index.ts
+++ b/src/form/addresses/index.ts
@@ -14,6 +14,7 @@ import {
   MOTHER_DETAILS_DONT_EXIST,
   SPOUSE_DETAILS_DONT_EXIST,
   detailsDontExist,
+  expressionToConditional,
   hideIfInformantBrideOrGroom,
   hideIfInformantSpouse,
   informantNotMotherOrFather,
@@ -121,14 +122,28 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
       {
         config: AddressSubsections.PRIMARY_ADDRESS_SUBSECTION,
         label: formMessageDescriptors.primaryAddress,
-        conditionalCase: `${FATHER_DETAILS_DONT_EXIST}`
+        conditionalCase: [
+          expressionToConditional(FATHER_DETAILS_DONT_EXIST),
+          expressionToConditional(
+            `${FATHER_DETAILS_DONT_EXIST} || ${primaryAddressSameAsOtherPrimaryAddress}`,
+            'hideInPreview'
+          )
+        ]
       },
       {
         config: AddressCopyConfigCases.PRIMARY_ADDRESS_SAME_AS_OTHER_PRIMARY,
         label: formMessageDescriptors.primaryAddressSameAsOtherPrimary,
         xComparisonSection: 'father',
         yComparisonSection: 'mother',
-        conditionalCase: `(${detailsDontExist} || ${mothersDetailsDontExistOnOtherPage})`
+        conditionalCase: [
+          expressionToConditional(
+            `(${detailsDontExist} || ${mothersDetailsDontExistOnOtherPage})`
+          ),
+          expressionToConditional(
+            `(${detailsDontExist} || ${mothersDetailsDontExistOnOtherPage} || !${primaryAddressSameAsOtherPrimaryAddress})`,
+            'hideInPreview'
+          )
+        ]
       },
       {
         config: AddressCases.PRIMARY_ADDRESS,

--- a/src/form/common/default-validation-conditionals.ts
+++ b/src/form/common/default-validation-conditionals.ts
@@ -15,7 +15,7 @@ import { Validator } from '../types/validators'
 /**
  * Turns a string expression into a Conditional object
  * @param expression conditional expression
- * @param action conditional action. e.g. 'hide' |'HideInPreview'. Defaults to 'hide'
+ * @param action conditional action. e.g. 'hide' |'hideInPreview'. Defaults to 'hide'
  */
 export const expressionToConditional = (
   expression: string,

--- a/src/form/common/default-validation-conditionals.ts
+++ b/src/form/common/default-validation-conditionals.ts
@@ -12,6 +12,19 @@ import { Conditional } from '../types/types'
 import { IntegratingSystemType } from '../types/types'
 import { Validator } from '../types/validators'
 
+/**
+ * Turns a string expression into a Conditional object
+ * @param expression conditional expression
+ * @param action conditional action. e.g. 'hide' |'HideInPreview'. Defaults to 'hide'
+ */
+export const expressionToConditional = (
+  expression: string,
+  action: string = 'hide'
+): Conditional => ({
+  action,
+  expression: `${expression}`
+})
+
 export const isValidChildBirthDate = [
   {
     operation: 'isValidChildBirthDate'

--- a/src/form/common/messages.ts
+++ b/src/form/common/messages.ts
@@ -128,7 +128,7 @@ export const informantMessageDescriptors = {
 export const formMessageDescriptors = {
   primaryAddress: {
     defaultMessage: 'Usual place of residence',
-    description: 'Title of the primary adress ',
+    description: 'Title of the primary adress',
     id: 'form.field.label.primaryAddress'
   },
   spouseSectionName: {

--- a/src/form/types/types.ts
+++ b/src/form/types/types.ts
@@ -927,7 +927,7 @@ export type AllowedAddressConfigurations = {
   label?: MessageDescriptor
   xComparisonSection?: string
   yComparisonSection?: string
-  conditionalCase?: string
+  conditionalCase?: string | Conditional[]
 }
 
 export type AdministrativeLevel = 1 | 2 | 3 | 4 | 5

--- a/src/utils/address-utils.ts
+++ b/src/utils/address-utils.ts
@@ -1100,30 +1100,29 @@ function getAddress(
     addressHierarchy
   )
   if (conditionalCase) {
-    defaultFields.forEach((field) => {
-      let conditional
-      if (typeof conditionalCase === 'string') {
-        conditional = expressionToConditional(conditionalCase)
-      }
-
-      // @TODO Update this to handle multiple conditionals if the changes are otherwise good
-      if (Array.isArray(conditionalCase)) {
-        conditional = conditionalCase[0]
-      }
-
-      if (
-        conditional &&
-        field.conditionals &&
-        field.conditionals.filter(
-          (conditional) => conditional.expression === conditionalCase
-        ).length === 0
-      ) {
-        field.conditionals.push(conditional)
-      } else if (conditional && !field.conditionals) {
-        field.conditionals = [conditional]
-      }
-    })
+    return addConditionalsToFields(defaultFields, conditionalCase)
   }
 
   return defaultFields
+}
+
+/**
+ * Adds provided conditionals to each field. Mutates the given array.
+ */
+function addConditionalsToFields(
+  fields: SerializedFormField[],
+  conditionalCase: string | Conditional[]
+) {
+  fields.forEach((field) => {
+    const conditionals =
+      typeof conditionalCase === 'string'
+        ? [expressionToConditional(conditionalCase)]
+        : conditionalCase
+
+    if (conditionals.length > 0) {
+      field.conditionals = [...(field.conditionals || []), ...conditionals]
+    }
+  })
+
+  return fields
 }


### PR DESCRIPTION
Show matching label depending on father's primary address selection.
- Extend `conditionalCase` type, allow passing `Conditional[]`


![preview-father-details](https://github.com/opencrvs/opencrvs-countryconfig/assets/6642742/019ab7c0-1f96-4162-9c18-a3683ee2f472)

I could not get to a nicely working solution without utilising the `Conditional` type. I opted for not trying to modify the `primaryAddress` `previewGroup` since it was much more involved.

Let me know what you think. ~~I left a todo comment which I intend to fix if you find the approach ok.~~

