### PR TITLE
fix: stop accessing response text multiple times

### DIFF
--- a/src/api/notification/sms-service.ts
+++ b/src/api/notification/sms-service.ts
@@ -80,15 +80,13 @@ export async function sendSMS(
   }
 
   const responseBody = await response.text()
-  logger.info(`Response from Infobip: ${JSON.stringify(responseBody)}`)
   if (!response.ok) {
-    logger.error(
-      `Failed to send sms to ${recipient}. Reason: ${response.text()}`
-    )
+    logger.error(`Failed to send sms to ${recipient}. Reason: ${responseBody}`)
     throw internal(
-      `Failed to send notification to ${recipient}. Reason: ${response.text()}`
+      `Failed to send notification to ${recipient}. Reason: ${responseBody}`
     )
   }
+  logger.info(`Response from Infobip: ${JSON.stringify(responseBody)}`)
 }
 
 const compileMessages = async (


### PR DESCRIPTION
As text is a stream it can only be accessed once otherwise it would error.