### PR TITLE
Include first commit to range, render commits to body

### DIFF
--- a/.github/workflows/auto-pr-to-release.yml
+++ b/.github/workflows/auto-pr-to-release.yml
@@ -120,7 +120,8 @@ jobs:
 
           echo "First commit: ${{ env.FIRST_COMMIT_SHA }}"
           echo "Latest commit: ${{ env.LATEST_COMMIT_SHA }}"
-          COMMIT_RANGE="${{ env.FIRST_COMMIT_SHA }}..${{ env.LATEST_COMMIT_SHA }}"
+          # NOTE: git cherry-pick range needs ~ to include the FIRST_COMMIT_SHA (https://stackoverflow.com/questions/1994463/how-to-cherry-pick-a-range-of-commits-and-merge-them-into-another-branch)
+          COMMIT_RANGE="${{ env.FIRST_COMMIT_SHA }}~..${{ env.LATEST_COMMIT_SHA }}"
 
           if [ "${{ env.FIRST_COMMIT_SHA }}" == "${{ env.LATEST_COMMIT_SHA }}" ]; then
             COMMIT_RANGE=${{ env.FIRST_COMMIT_SHA }}
@@ -133,6 +134,9 @@ jobs:
             git cherry-pick --abort || true
             # If cherry-pick fails, create a placeholder commit
             echo "Cherry-pick failed. Creating placeholder commit."
+
+            GIT_LOG_ONELINE_OUTPUT=$(git log --oneline --no-decorate $COMMIT_RANGE)
+
             git reset --hard
             git commit --allow-empty -m "Placeholder commit for PR #${{ env.PR_ID }}"
 
@@ -153,6 +157,12 @@ jobs:
             git checkout $NEW_BRANCH
             git reset --hard HEAD~1  # Remove placeholder commit
             git cherry-pick $COMMIT_RANGE
+            \`\`\`
+
+
+            **Individual commits:**
+            \`\`\`
+            $GIT_LOG_ONELINE_OUTPUT
             \`\`\`
             "
           }


### PR DESCRIPTION
Same changes: https://github.com/opencrvs/opencrvs-core/pull/7397
Issue:
1. When the PR bot was successful, the first commit got removed due `cherry-pick` behaviour.  In `git cherry-pick h4shba..h4ashb` left side is exclusive. It differs from what `git log` shows with corresponding range syntax.
2. The commands provided by PR had the same behaviour. From a quick look there has not been many manual "Merge changes from PR" fixes that utilise the provided syntax. People tend to fix it by other means.
3. When referring to commit range, it can exists in multiple branches. Picking from `develop`
yields different result than the feature branch.

Changes:
1. Include first commit to cherry-pick range
2. Print out commits to PR body when automatic cherry-pick fails.

Sample PR: https://github.com/opencrvs/opencrvs-core/pull/7395

Further steps if needed:
- Consider whether we can cherry-pick based on branch rather than range ( e.g. `git cherry-pick origin/release-v1.6.0..origin/chore/ocrvs-7133-eslint-warnings`)
  - `develop` might include more merge commits, and commits related to different releases than the target release within the range.  Ranges with merge commits will fail automatic cherry-pick without `--mainline`
  - I assume `git cherry-pick´ implicitly defaults to main branch (`develop`) when picking a range if there are multiple options.
- Consider adopting consistent rules for branching for easier cherry-picking.
  - Prevent updating branch `Merge branch 'develop' into chore/ocrvs-7133-eslint-warnings` /  adopt rebasing to `develop`.

