### PR TITLE
Fix/custom ssh port config

### DIFF
--- a/infrastructure/server-setup/inventory/qa.yml
+++ b/infrastructure/server-setup/inventory/qa.yml
@@ -21,6 +21,8 @@ docker-manager-first:
   hosts:
     qa: # @todo set this to be the hostname of your target server
       ansible_host: '55.55.55.55' # @todo set this to be the IP address of your server
+      # ansible_port: '23' # @todo set this to be the SSH port if it's not 22
+      # internal_ssh_port: '22' # @todo if you are port-forwarding and server SSH port is not the same as ansible_port, set it here
       data_label: data1 # for manager machines, this should always be "data1"
 
 # QA and staging servers are not configured to use workers.

--- a/infrastructure/server-setup/tasks/ufw.yml
+++ b/infrastructure/server-setup/tasks/ufw.yml
@@ -5,7 +5,7 @@
 
 - name: Set default SSH port
   set_fact:
-    ssh_port: '{{ internal_ssh_port | ansible_port | default(22) }}'
+    ssh_port: '{{ internal_ssh_port | default(ansible_port) | default(22) }}'
 
 - name: Allow OpenSSH for IPv4 from specific addresses
   ufw:

--- a/infrastructure/server-setup/tasks/ufw.yml
+++ b/infrastructure/server-setup/tasks/ufw.yml
@@ -3,6 +3,10 @@
     name: ufw
     state: present
 
+- name: Set default SSH port
+  set_fact:
+    ssh_port: '{{ internal_ssh_port | ansible_port | default(22) }}'
+
 - name: Allow OpenSSH for IPv4 from specific addresses
   ufw:
     rule: allow
@@ -11,10 +15,6 @@
     src: '{{ item }}'
   loop: '{{ only_allow_access_from_addresses }}'
   when: only_allow_access_from_addresses is defined and only_allow_access_from_addresses | length > 0
-
-- name: Set default SSH port
-  set_fact:
-    ssh_port: '{{ ansible_port | default(22) }}'
 
 - name: Remove general OpenSSH allow rule
   ufw:

--- a/infrastructure/server-setup/tasks/ufw.yml
+++ b/infrastructure/server-setup/tasks/ufw.yml
@@ -10,7 +10,7 @@
 - name: Allow OpenSSH for IPv4 from specific addresses
   ufw:
     rule: allow
-    port: 22
+    port: '{{ ssh_port }}'
     proto: tcp
     src: '{{ item }}'
   loop: '{{ only_allow_access_from_addresses }}'


### PR DESCRIPTION
Setup:
1. System uses custom ssh port (e.g. 23)
2. System port-forwards SSH connection (e.g. 22)
3. Server uses different SSH port than the external interface (e.g. 22)

Allow defining internal ssh port in order to prevent UFW locking us out
