### PR TITLE
Fix environment creator asking user to resupply some Github variables and secrets on every run

### DIFF
--- a/infrastructure/environments/github.ts
+++ b/infrastructure/environments/github.ts
@@ -244,9 +244,11 @@ export async function listEnvironmentSecrets(
     {
       owner: owner,
       repository_id: repositoryId,
-      environment_name: environmentName
+      environment_name: environmentName,
+      per_page: 100
     }
   )
+
   return response.data.secrets.map((secret) => ({
     ...secret,
     type: 'SECRET',
@@ -263,7 +265,8 @@ export async function listRepositorySecrets(
     'GET /repos/{owner}/{repo}/actions/secrets',
     {
       owner: owner,
-      repo: repositoryName
+      repo: repositoryName,
+      per_page: 100
     }
   )
   return response.data.secrets.map((secret) => ({
@@ -281,9 +284,9 @@ export async function listEnvironmentVariables(
   const response = await octokit.request(
     'GET /repositories/{repository_id}/environments/{environment_name}/variables',
     {
-      per_page: 30,
       repository_id: repositoryId,
       environment_name: environmentName,
+      per_page: 100,
       headers: {
         'X-GitHub-Api-Version': '2022-11-28'
       }


### PR DESCRIPTION
What had happened was by default Github APIs only return 30 first secrets / variables. 
This caused `SSH_KEY`, `SSH_USER` and other variables at the end of the variables list to always be asked from the user.