### PR TITLE
fix(releasing): Explicitly specify from which branch the release tag should be created from OCRVS-7369

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -72,6 +72,7 @@ jobs:
           type: now
           from_branch: ${{ github.event.inputs.branch_name }}
           target_branch: master
+          message: Merge ${{ github.event.inputs.branch_name }} to master
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge master -> develop
@@ -80,4 +81,5 @@ jobs:
           type: now
           from_branch: master
           target_branch: develop
+          message: Merge master back to develop
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,7 @@ on:
         description: Branch to build from
         default: master
         required: true
+
       release_version:
         description: Release tag. It will be prepended by your repository name
         required: true
@@ -45,6 +46,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: ${{ github.event.repository.name }}-
           custom_tag: ${{ env.TAG }}
+          release_branches: ${{ github.event.inputs.branch_name }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,7 +9,7 @@ on:
         required: true
 
       release_version:
-        description: Release tag. It will be prepended by your repository name
+        description: Release tag. It will be prepended by your repository name (e.g. 1.5.3 or 20240501)
         required: true
 
 jobs:
@@ -23,12 +23,8 @@ jobs:
       - name: Install jq
         run: sudo apt-get install jq -y
 
-      - name: Read version from package.json
-        id: get_version
-        run: echo "::set-output name=version::$(jq -r '.version' package.json)"
-
       - name: Set TAG environment variable
-        run: echo "TAG=v${{ steps.get_version.outputs.version }}" >> $GITHUB_ENV
+        run: echo "TAG=v${{ github.event.inputs.release_version }}" >> $GITHUB_ENV
 
       - uses: trstringer/manual-approval@v1
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,7 +9,7 @@ on:
         required: true
 
       release_version:
-        description: Release tag. It will be prepended by your repository name (e.g. 1.5.3 or 20240501)
+        description: Release tag. It will be prepended by your repository name (e.g. v1.5.3 or 20240501)
         required: true
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
         run: sudo apt-get install jq -y
 
       - name: Set TAG environment variable
-        run: echo "TAG=v${{ github.event.inputs.release_version }}" >> $GITHUB_ENV
+        run: echo "TAG=${{ github.event.inputs.release_version }}" >> $GITHUB_ENV
 
       - uses: trstringer/manual-approval@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-
 ## 1.7.0 Release candidate
 
 ### Bug fixes
 
 - Kibana disk space alerts now work regardless of your disk device names. Alerts listen devices mounted both to `/` and `/data` (encrypted data partition)
+- "Publish release" pipeline now correctly uses the "Branch to build from" value as the branch to be tagged. Previously it tried tagging "master". "Release tag" is also now used as the release version as is instead of it being read from `package.json`.
 
 ### Breaking changes
 
@@ -123,7 +123,7 @@ INSERT CSV ROWS IN ENGLISH ONLY
 - **Check your Metabase map file.** For Metabase configuration, we renamed `farajaland-map.geojson` to `map.geojson` to not tie implementations into example country naming conventions.
 - **Feature flags** In order to make application config settings more readable, we re-organised `src/api/application/application-config-default.ts` with a clear feature flag block like so. These are then used across the front and back end of the application to control configurable functionality. New feature flags DEATH_REGISTRATION allow you to optionally run off death registration if your country doesnt want to run its first pilot including death and PRINT_DECLARATION (see New Features) have been added.
   `FEATURES: {
-  DEATH_REGISTRATION: true, 
+  DEATH_REGISTRATION: true,
   MARRIAGE_REGISTRATION: false,
   ...
 } `


### PR DESCRIPTION
A few small fixes here:
- Fix tagging mechanism so it always uses the branch defined as the "Branch to build from"
- Add descriptive commit messages to merge commits created by the pipeline
- Use the "Release tag" input as the tag to be created instead of reading a version from package.json
- Remove `v___` prefix from tags to allow countries use whatever versioning scheme