### PR TITLE
chore: remove storybook from deployment

### DIFF
--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -524,31 +524,6 @@ services:
         gelf-address: 'udp://127.0.0.1:12201'
         tag: 'client'
 
-  components:
-    deploy:
-      labels:
-        - 'traefik.enable=true'
-        - 'traefik.http.routers.components.rule=Host(`ui-kit.{{hostname}}`)'
-        - 'traefik.http.services.components.loadbalancer.server.port=80'
-        - 'traefik.http.routers.components.tls=true'
-        - 'traefik.http.routers.components.tls.certresolver=certResolver'
-        - 'traefik.http.routers.components.entrypoints=web,websecure'
-        - 'traefik.docker.network=opencrvs_overlay_net'
-        - 'traefik.http.middlewares.components.headers.customresponseheaders.Pragma=no-cache'
-        - 'traefik.http.middlewares.components.headers.customresponseheaders.Cache-control=no-store'
-        - 'traefik.http.middlewares.components.headers.customresponseheaders.X-Robots-Tag=none'
-        - 'traefik.http.middlewares.components.headers.stsseconds=31536000'
-        - 'traefik.http.middlewares.components.headers.stsincludesubdomains=true'
-        - 'traefik.http.middlewares.components.headers.stspreload=true'
-      replicas: 1
-    networks:
-      - overlay_net
-    logging:
-      driver: gelf
-      options:
-        gelf-address: 'udp://127.0.0.1:12201'
-        tag: 'components'
-
   countryconfig:
     deploy:
       labels:

--- a/infrastructure/docker-compose.staging-deploy.yml
+++ b/infrastructure/docker-compose.staging-deploy.yml
@@ -124,10 +124,6 @@ services:
     deploy:
       replicas: 1
 
-  components:
-    deploy:
-      replicas: 1
-
   login:
     deploy:
       replicas: 1


### PR DESCRIPTION
We started deploying Storybook to Cloudflare Pages ( opencrvs.pages.dev ) so we don't need to include it in deployments anymore.