### PR TITLE
feat: ask for COUNTRY in setup environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Improvements
 
 - Auth token, ip address, remote address, mobile number, email redacted/masked from server log
+- Country alpha3 ISO code now is derived from variables to the Docker Compose files and don't need to be hard coded
 
 ### Infrastructure breaking changes
 
@@ -104,7 +105,6 @@ INSERT CSV ROWS IN ENGLISH ONLY
   - `sent-for-updates`
 
 - **`/record-notification` API**: Endpoint to check enabled notifications for records. The API returns the `notificationForRecord` object for `BIRTH` and `DEATH` events, listing their respective flags. Route configuration includes description and tags for API documentation.
-
 
 ### New content keys requiring translation
 

--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -704,6 +704,7 @@ services:
       - LOGIN_URL=https://login.{{hostname}}
       - CLIENT_APP_URL=https://register.{{hostname}}
       - DOMAIN={{hostname}}
+      - COUNTRY=${COUNTRY}
     deploy:
       labels:
         - 'traefik.enable=true'

--- a/infrastructure/docker-compose.development-deploy.yml
+++ b/infrastructure/docker-compose.development-deploy.yml
@@ -41,7 +41,7 @@ services:
     environment:
       - LANGUAGES=en,fr
       - SENTRY_DSN=${SENTRY_DSN:-}
-      - COUNTRY=FAR
+      - COUNTRY=${COUNTRY}
       - QA_ENV=true
       - NODE_ENV=production
 

--- a/infrastructure/docker-compose.qa-deploy.yml
+++ b/infrastructure/docker-compose.qa-deploy.yml
@@ -70,7 +70,7 @@ services:
     environment:
       - LANGUAGES=en,fr
       - SENTRY_DSN=${SENTRY_DSN:-}
-      - COUNTRY=FAR
+      - COUNTRY=${COUNTRY}
       - QA_ENV=true
       - NODE_ENV=production
 

--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -329,7 +329,7 @@ const sshQuestions = [
     name: 'sshHost',
     type: 'text' as const,
     message:
-      'What is the target server IP address? (Note: For "production" environment with 2, 3 or 5 servers, this is the IP address of the manager server',
+      'What is the target server IP address? (Note: For "production" environment with 2, 3 or 5 servers, this is the IP address of the manager server)',
     valueType: 'VARIABLE' as const,
     validate: notEmpty,
     valueLabel: 'SSH_HOST',
@@ -370,6 +370,19 @@ const sshKeyQuestions = [
     valueLabel: 'SSH_KEY',
     initial: process.env.SSH_KEY,
     scope: 'ENVIRONMENT' as const
+  }
+]
+
+const countryQuestions = [
+  {
+    name: 'country',
+    type: 'text' as const,
+    message:
+      'What is the ISO 3166-1 alpha-3 country-code? (e.g. "NZL" for New Zealand) Reference: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3',
+    valueType: 'VARIABLE' as const,
+    valueLabel: 'COUNTRY',
+    initial: process.env.COUNTRY,
+    scope: 'REPOSITORY' as const
   }
 ]
 
@@ -754,6 +767,7 @@ ALL_QUESTIONS.push(
   ...sshQuestions,
   ...sshKeyQuestions,
   ...infrastructureQuestions,
+  ...countryQuestions,
   ...databaseAndMonitoringQuestions,
   ...notificationTransportQuestions,
   ...smsQuestions,
@@ -1026,6 +1040,7 @@ const SPECIAL_NON_APPLICATION_ENVIRONMENTS = ['jump', 'backup']
   const answerOrExisting = (
     variable: string | undefined,
     existingValue: Variable | undefined,
+    // eslint-disable-next-line no-unused-vars
     fn: (value: string | undefined) => string
   ) => fn(variable || existingValue?.value) || ''
 


### PR DESCRIPTION
The country value is defaulted to FAR in core, but it changes per every environment so it shouldn't be defaulted in production. The environment validation caught this issue. Updated to ask for it in the setup environment script.