### PR TITLE
feat: Add humanName constant to the copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - **Major new feature** Description
 - Misc new feature
+- Add constant.humanName to allow coutries to have custom ordering on thier full name e.g start with `lastName` or `firstName` [#6830](https://github.com/opencrvs/opencrvs-core/issues/6830)
 
 ### New content keys requiring translation
 

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -265,6 +265,7 @@ constants.gender,Gender label,Gender,Sexe
 constants.healthDivision,The description for HEALTH_DIVISION type,Health Division,Division de la santé
 constants.healthcareWorker,The description for Healthcare Worker type,Healthcare Worker,Travailleur de la santé
 constants.history,History heading,History,Histoire
+constants.humanName,Formatted full name, {lastName} {middleName} {firstName},{lastName} {middleName} {firstName}
 constants.id,ID Label,ID,ID
 constants.idCheckWithoutVerify,Issuance without the confirmation of proof,Continue without proof of ID?,Continuer sans preuve d'identité?
 constants.inReview.status,A label for In Review,In review,En cours de révision


### PR DESCRIPTION
This is to allow country implementation to have custom Full name ordering e.g start with LastName or FirstName

https://github.com/opencrvs/opencrvs-core/issues/6830