### PR TITLE
Always retry mongo-on-update on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - "Publish release" pipeline now correctly uses the "Branch to build from" value as the branch to be tagged. Previously it tried tagging "master". "Release tag" is also now used as the release version as is instead of it being read from `package.json`.
 - Backup process now doesn't require internet connection to download docker images thus working more reliably when internet connections are unreliable. Previously non-active images were cleaned nightly, now we only do it as part of deployment. [#7896](https://github.com/opencrvs/opencrvs-core/issues/7896)
 - We make sure that the automatic cleanup job only runs before deployment (instead of cron schedule cleanup).
+- Previously it was possible MongoDB replica set and users were left randomly uninitialised after a deployment. MongoDB initialisation container now retries on failure.
+- On some machines 'file' utility was not preinstalled causing provision to fail. We now install the utility if it doesn't exist.
 
 ### Breaking changes
 

--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -226,8 +226,11 @@ services:
       labels:
         - traefik.enable=false
       replicas: 1
+      # If this doesn't get run successfully, both the replica set in mongo and
+      # the user schema remains uninitialized.
       restart_policy:
-        condition: none
+        condition: on-failure
+        delay: 10s
     environment:
       - REPLICAS=1
       - MONGODB_ADMIN_USER=${MONGODB_ADMIN_USER}

--- a/infrastructure/server-setup/tasks/swap.yml
+++ b/infrastructure/server-setup/tasks/swap.yml
@@ -14,6 +14,13 @@
   tags:
     - swap.file.permissions
 
+- name: Ensure 'file' utility is installed
+  ansible.builtin.package:
+    name: file
+    state: present
+  tags:
+    - swap.file.mkswap
+
 - name: 'Check swap file type'
   command: file {{ swap_file_path }}
   register: swapfile


### PR DESCRIPTION
Minor improvements for things I found while testing 1.6.0 infrastructure.

While I was testing 1.6.0, I noticed my staging environment not working. When trying to reset and seed the environment, I noticed reset not working as there was no replica set initialised in MongoDB. What had happened was this service failing for whatever reason. Kicking it back up and then doing a reset fixed the issue.