### PR TITLE
chore(v1.6.1): Add initial value type to match types in core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ INSERT CSV ROWS IN ENGLISH ONLY
 - Github pipeline dedicated for reading secrets and variables from other environments now checks if GH_TOKEN is still valid before attempting other operations
 - Remove unnecessary UI dividers that add in various sections of the declaration forms(e.g the Death, Birth and Marriage forms) [#244](https://github.com/opencrvs/opencrvs-countryconfig/pull/244)
 - Update template transformer for fields `informantType` and `otherInformantType` that fixes the bug of unavailability of these template fields [#5952](https://github.com/opencrvs/opencrvs-countryconfig/pull/5952)
+- Fixed missing InitialValue property to set initial values based on an expression
 
 ## 1.5.2 (https://github.com/opencrvs/opencrvs-countryconfig/compare/v1.5.1...v1.5.2)
 

--- a/src/form/types/types.ts
+++ b/src/form/types/types.ts
@@ -562,7 +562,7 @@ export interface IFormFieldBase {
   disabled?: boolean
   enabled?: string
   custom?: boolean
-  initialValue?: IFormFieldValue
+  initialValue?: InitialValue
   initialValueKey?: string
   extraValue?: IFormFieldValue
   conditionals?: Conditional[]
@@ -837,6 +837,13 @@ export interface IDateRangePickerValue {
   rangeEnd: string | undefined
   isDateRangeActive: boolean | undefined
 }
+
+export type DependencyInfo = {
+  expression: string
+  dependsOn: string[]
+}
+
+export type InitialValue = IFormFieldValue | DependencyInfo
 
 export type IFormFieldValue =
   | string


### PR DESCRIPTION
InitialValue can be used with the expression property in core to dynamically set the value based on other fields.
This PR syncs the types with the country config to make that functionality clear.