### PR TITLE
Refactor: Removed Traefik configurations that exposes auth to the public internet

### DIFF
--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -633,18 +633,7 @@ services:
     deploy:
       labels:
         - 'traefik.enable=true'
-        - 'traefik.http.routers.auth.rule=Host(`auth.{{hostname}}`)'
-        - 'traefik.http.services.auth.loadbalancer.server.port=4040'
-        - 'traefik.http.routers.auth.tls=true'
-        - 'traefik.http.routers.auth.tls.certresolver=certResolver'
-        - 'traefik.http.routers.auth.entrypoints=web,websecure'
         - 'traefik.docker.network=opencrvs_overlay_net'
-        - 'traefik.http.middlewares.auth.headers.customresponseheaders.Pragma=no-cache'
-        - 'traefik.http.middlewares.auth.headers.customresponseheaders.Cache-control=no-store'
-        - 'traefik.http.middlewares.auth.headers.customresponseheaders.X-Robots-Tag=none'
-        - 'traefik.http.middlewares.auth.headers.stsseconds=31536000'
-        - 'traefik.http.middlewares.auth.headers.stsincludesubdomains=true'
-        - 'traefik.http.middlewares.auth.headers.stspreload=true'
       replicas: 1
     networks:
       - overlay_net

--- a/src/login-config.js
+++ b/src/login-config.js
@@ -10,6 +10,7 @@
  */
 window.config = {
   AUTH_API_URL: 'http://localhost:7070/auth/',
+  API_GATEWAY_URL: 'http://localhost:7070/',
   CONFIG_API_URL: 'http://localhost:2021',
   // Country code in uppercase ALPHA-3 format
   COUNTRY: 'FAR',

--- a/src/login-config.prod.js
+++ b/src/login-config.prod.js
@@ -10,6 +10,7 @@
  */
 window.config = {
   AUTH_API_URL: 'https://gateway.{{hostname}}/auth/',
+  API_GATEWAY_URL: 'https://gateway.{{hostname}}/',
   CONFIG_API_URL: 'https://config.{{hostname}}',
   // Country code in uppercase ALPHA-3 format
   COUNTRY: 'FAR',


### PR DESCRIPTION
[#7818 in opencrvs-core](https://github.com/opencrvs/opencrvs-core/issues/7818)

- Removed Traefik configurations
- Replaced AUTH_URL usages in client & login apps with API_GATEWAY_URL/api/auth