### PR TITLE
INFORMANT_SIGNATURE & INFORMANT_SIGNATURE_REQUIRED are now deprecated…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ INSERT CSV ROWS IN ENGLISH ONLY
 
 - TBC
 
+## 1.6.2 Release candidate
+
+### Deprecated
+
+- `INFORMANT_SIGNATURE` & `INFORMANT_SIGNATURE_REQUIRED` are now deprecated
+
 ## 1.6.1 (TBD)
 
 ### Bug fixes

--- a/src/api/application/application-config.ts
+++ b/src/api/application/application-config.ts
@@ -44,10 +44,8 @@ export const applicationConfig = {
     DEATH_REGISTRATION: true,
     MARRIAGE_REGISTRATION: false,
     EXTERNAL_VALIDATION_WORKQUEUE: false,
-    INFORMANT_SIGNATURE: false,
     PRINT_DECLARATION: false,
-    DATE_OF_BIRTH_UNKNOWN: true,
-    INFORMANT_SIGNATURE_REQUIRED: false
+    DATE_OF_BIRTH_UNKNOWN: true
   },
   USER_NOTIFICATION_DELIVERY_METHOD: 'email', // or 'sms', or '' ... You can use 'sms' for WhatsApp
   INFORMANT_NOTIFICATION_DELIVERY_METHOD: 'email', // or 'sms', or '' ... You can use 'sms' for WhatsApp


### PR DESCRIPTION
… and part of form config

https://github.com/opencrvs/opencrvs-core/issues/8228