### PR TITLE
OCRVS-8300 Workflow added which will close PR after 30 days of inactivity

### DIFF
--- a/.github/workflows/close-stale-prs-after-30-days.yml
+++ b/.github/workflows/close-stale-prs-after-30-days.yml
@@ -1,19 +1,19 @@
 name: 'Close stale PRs after 30 days'
 on:
-    schedule:
-        - cron: '0 0 * * *'
-    workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 
 permissions:
-    pull-requests: write
-    
+  pull-requests: write
+
 jobs:
-    stale:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/stale@v9
-              with:
-                stale-pr-message: 'This PR has been marked with label stale Since it has been inactive for 20 days. It will automatically be closed in 10 days if no further activity occurs.'
-                close-pr-message: 'This PR has been automatically closed because it has been inactive for 30 days. Please reopen if you are still working on it.'
-                days-before-pr-stale: 20
-                days-before-pr-close: 10
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: 'This PR has been marked with label stale Since it has been inactive for 20 days. It will automatically be closed in 10 days if no further activity occurs.'
+          close-pr-message: 'This PR has been automatically closed because it has been inactive for 30 days. Please reopen if you are still working on it.'
+          days-before-pr-stale: 20
+          days-before-pr-close: 10

--- a/.github/workflows/close-stale-prs-after-30-days.yml
+++ b/.github/workflows/close-stale-prs-after-30-days.yml
@@ -1,0 +1,19 @@
+name: 'Close stale PRs after 30 days'
+on:
+    schedule:
+        - cron: '0 0 * * *'
+    workflow_dispatch:
+
+permissions:
+    pull-requests: write
+    
+jobs:
+    stale:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/stale@v9
+              with:
+                stale-pr-message: 'This PR has been marked with label stale Since it has been inactive for 20 days. It will automatically be closed in 10 days if no further activity occurs.'
+                close-pr-message: 'This PR has been automatically closed because it has been inactive for 30 days. Please reopen if you are still working on it.'
+                days-before-pr-stale: 20
+                days-before-pr-close: 10


### PR DESCRIPTION
This workflow will add a label Stale to a PR (if the PR remains inactive for 20 days)
After 10 days of labeling a PR to stale it will close the PR.
and send some messages to the author.

**The main purpose of the workflow is Closing a PR which is inactive for 30 days**