### PR TITLE
overwrite the core compose files in /tmp

### DIFF
--- a/infrastructure/deployment/deploy.sh
+++ b/infrastructure/deployment/deploy.sh
@@ -356,7 +356,7 @@ export ROTATING_APM_ELASTIC_PASSWORD=`generate_password`
 # Download core compose files to /tmp/
 for compose_file in ${COMPOSE_FILES_DOWNLOADED_FROM_CORE[@]}; do
     echo "Downloading $compose_file from https://raw.githubusercontent.com/opencrvs/opencrvs-core/$VERSION/$(basename $compose_file)"
-    curl -o $compose_file https://raw.githubusercontent.com/opencrvs/opencrvs-core/$VERSION/$(basename $compose_file)
+    curl --fail -o $compose_file https://raw.githubusercontent.com/opencrvs/opencrvs-core/$VERSION/$(basename $compose_file)
 done
 
 validate_environment_variables

--- a/infrastructure/deployment/deploy.sh
+++ b/infrastructure/deployment/deploy.sh
@@ -355,10 +355,8 @@ export ROTATING_APM_ELASTIC_PASSWORD=`generate_password`
 
 # Download core compose files to /tmp/
 for compose_file in ${COMPOSE_FILES_DOWNLOADED_FROM_CORE[@]}; do
-  if [ ! -f $compose_file ]; then
     echo "Downloading $compose_file from https://raw.githubusercontent.com/opencrvs/opencrvs-core/$VERSION/$(basename $compose_file)"
     curl -o $compose_file https://raw.githubusercontent.com/opencrvs/opencrvs-core/$VERSION/$(basename $compose_file)
-  fi
 done
 
 validate_environment_variables


### PR DESCRIPTION
removes existing file check for the core compose files and downloads the new compose files when the script runs.

if the files existed on the server, this deployed the old version not the updated version.