### PR TITLE
influxdb: set max value per tag to unlimited

### DIFF
--- a/infrastructure/influxdb.conf
+++ b/infrastructure/influxdb.conf
@@ -16,6 +16,7 @@ bind-address = ":8088"
   dir = "/var/lib/influxdb/data"
   engine = "tsm1"
   wal-dir = "/var/lib/influxdb/wal"
+  max-values-per-tag = 0
 
 [http]
   flux-enabled=true


### PR DESCRIPTION
We got this influxdb error when loading 100,000 records and after that no more records could be inserted.

`{"level":50,"time":1738146685445,"pid":28,"hostname":"180ff405dc1a","msg":"Error saving data to InfluxDB! Error: A 400 Bad Request error occurred: {\"error\":\"partial write: max-values-per-tag limit exceeded (100000/100000): measurement=\\\"declaration_time_logged\\\" tag=\\\"trackingId\\\" value=\\\"BYKNEEM\\\" dropped=1\"}\n\n    at IncomingMessage.<anonymous> (/app/node_modules/influx/lib/src/pool.js:50:38)\n    at /app/node_modules/elastic-apm-node/lib/instrumentation/run-context/AbstractRunContextManager.js:95:49\n    at AsyncLocalStorage.run (node:async_hooks:327:14)\n    at AsyncLocalStorageRunContextManager.with (/app/node_modules/elastic-apm-node/lib/instrumentation/run-context/AsyncLocalStorageRunContextManager.js:57:36)\n    at IncomingMessage.wrapper (/app/node_modules/elastic-apm-node/lib/instrumentation/run-context/AbstractRunContextManager.js:95:23)\n    at IncomingMessage.emit (node:events:529:35)\n    at IncomingMessage.emit (node:domain:489:12)\n    at endReadableNT (node:internal/streams/readable:1400:12)\n    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)"}`

as per the documentation we set the value to 0, and the issues was fixed. 

https://docs.influxdata.com/influxdb/v1/administration/config/#max-values-per-tag--100000