### PR TITLE
fix: project _id from Task to corrections

### DIFF
--- a/src/api/dashboards/queries.ts
+++ b/src/api/dashboards/queries.ts
@@ -617,6 +617,7 @@ const declarations = ({ lastUpdatedAt }: { lastUpdatedAt: string }) => ({
     { $unwind: '$state' },
     {
       $project: {
+        _id: 1,
         gender: '$child.gender',
         reason: '$reason.text',
         extensions: '$extensions',


### PR DESCRIPTION
The generated documents were being merged into the corrections collection on `_id` field but as they were not being projected from the parent document, a new one was generated for each which defeated the purpose of them being used as the basis for merging.