### PR TITLE
chore: update fields to match toolkit changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/toolkit": "0.0.34-rr",
+    "@opencrvs/toolkit": "0.0.35-ml",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",
     "@types/fhir": "^0.0.30",
@@ -105,7 +105,7 @@
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^3.8.0",
     "typescript": "^5.1.6",
-    "zod": "^3.17.3"
+    "zod": "^3.24.1"
   },
   "lint-staged": {
     "src/**/*.{ts,graphql}": [

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/toolkit": "0.0.35-ml",
+    "@opencrvs/toolkit": "0.0.37-ml",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",
     "@types/fhir": "^0.0.30",

--- a/src/form/tennis-club-membership.ts
+++ b/src/form/tennis-club-membership.ts
@@ -791,14 +791,13 @@ export const tennisClubMembershipEvent = defineConfig({
             {
               id: 'correction.requester.relationship',
               type: 'RADIO_GROUP',
-              options: {},
               label: {
                 id: 'v2.correction.corrector.title',
                 defaultMessage: 'Who is requesting a change to this record?',
                 description: 'The title for the corrector form'
               },
               initialValue: '',
-              optionValues: [
+              options: [
                 {
                   value: 'INFORMANT',
                   label: {
@@ -860,7 +859,6 @@ export const tennisClubMembershipEvent = defineConfig({
             {
               id: 'correction.identity-check.verified',
               type: 'RADIO_GROUP',
-              options: {},
               label: {
                 id: 'correction.corrector.identity.verified.label',
                 defaultMessage: 'Identity verified',
@@ -868,7 +866,7 @@ export const tennisClubMembershipEvent = defineConfig({
               },
               initialValue: '',
               required: true,
-              optionValues: [
+              options: [
                 {
                   value: 'VERIFIED',
                   label: {
@@ -920,10 +918,12 @@ export const tennisClubMembershipEvent = defineConfig({
                 description: 'The title for the corrector form'
               },
               initialValue: '',
-              options: {
-                size: 'NORMAL'
+              configuration: {
+                styles: {
+                  size: 'NORMAL'
+                }
               },
-              optionValues: [
+              options: [
                 {
                   value: 'ATTEST',
                   label: {

--- a/src/form/v2/birth/__snapshots__/birth.test.ts.snap
+++ b/src/form/v2/birth/__snapshots__/birth.test.ts.snap
@@ -4,6 +4,16 @@ exports[`birth configuration is parsed 1`] = `
 {
   "actions": [
     {
+      "conditionals": [],
+      "forms": [],
+      "label": {
+        "defaultMessage": "Create",
+        "description": "This is shown as the action name anywhere the user can trigger the action from",
+        "id": "event.birth.action.create.label",
+      },
+      "type": "CREATE",
+    },
+    {
       "conditionals": [
         {
           "conditional": {
@@ -47,6 +57,7 @@ exports[`birth configuration is parsed 1`] = `
               ],
               "type": "object",
             },
+            "required": [],
             "type": "object",
           },
           "type": "SHOW",
@@ -58,7 +69,7 @@ exports[`birth configuration is parsed 1`] = `
           "label": {
             "defaultMessage": "Birth decalration form",
             "description": "This is what this form is referred as in the system",
-            "id": "event.birth.action.declare.form.label",
+            "id": "v2.event.birth.action.declare.form.label",
           },
           "pages": [
             {
@@ -71,28 +82,28 @@ exports[`birth configuration is parsed 1`] = `
                     {
                       "defaultMessage": "I am going to help you make a declaration of birth.",
                       "description": "Form information for birth",
-                      "id": "form.section.information.birth.bullet1",
+                      "id": "v2.form.section.information.birth.bullet1",
                     },
                     {
                       "defaultMessage": "As the legal Informant it is important that all the information provided by you is accurate.",
                       "description": "Form information for birth",
-                      "id": "form.section.information.birth.bullet2",
+                      "id": "v2.form.section.information.birth.bullet2",
                     },
                     {
                       "defaultMessage": "Once the declaration is processed you will receive an SMS to tell you when to visit the office to collect the certificate - Take your ID with you.",
                       "description": "Form information for birth",
-                      "id": "form.section.information.birth.bullet3",
+                      "id": "v2.form.section.information.birth.bullet3",
                     },
                     {
                       "defaultMessage": "Make sure you collect the certificate. A birth certificate is critical for this child, especially to make their life easy later on. It will help to access health services, school examinations and government benefits.",
                       "description": "Form information for birth",
-                      "id": "form.section.information.birth.bullet4",
+                      "id": "v2.form.section.information.birth.bullet4",
                     },
                   ],
                   "label": {
                     "defaultMessage": "Birth Information",
                     "description": "Label for the birth information bullet list",
-                    "id": "form.section.information.birth.bulletList.label",
+                    "id": "v2.form.section.information.birth.bulletList.label",
                   },
                   "type": "BULLET_LIST",
                 },
@@ -101,7 +112,7 @@ exports[`birth configuration is parsed 1`] = `
               "title": {
                 "defaultMessage": "Introduce the birth registration process to the informant",
                 "description": "Event information title for the birth",
-                "id": "register.eventInfo.birth.title",
+                "id": "v2.register.eventInfo.birth.title",
               },
             },
             {
@@ -111,7 +122,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "First name(s)",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.child.field.firstname.label",
+                    "id": "v2.event.birth.action.declare.form.section.child.field.firstname.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -121,7 +132,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Last name",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.child.field.surname.label",
+                    "id": "v2.event.birth.action.declare.form.section.child.field.surname.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -131,14 +142,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Sex",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.child.field.gender.label",
+                    "id": "v2.event.birth.action.declare.form.section.child.field.gender.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "Male",
                         "description": "Label for option male",
-                        "id": "form.field.label.sexMale",
+                        "id": "v2.form.field.label.sexMale",
                       },
                       "value": "male",
                     },
@@ -146,7 +157,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Female",
                         "description": "Label for option female",
-                        "id": "form.field.label.sexFemale",
+                        "id": "v2.form.field.label.sexFemale",
                       },
                       "value": "female",
                     },
@@ -154,7 +165,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Unknown",
                         "description": "Label for option unknown",
-                        "id": "form.field.label.sexUnknown",
+                        "id": "v2.form.field.label.sexUnknown",
                       },
                       "value": "unknown",
                     },
@@ -167,7 +178,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Date of birth",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.child.field.dob.label",
+                    "id": "v2.event.birth.action.declare.form.section.child.field.dob.label",
                   },
                   "required": true,
                   "type": "DATE",
@@ -176,7 +187,7 @@ exports[`birth configuration is parsed 1`] = `
                       "message": {
                         "defaultMessage": "Please enter a valid date",
                         "description": "This is the error message for invalid date",
-                        "id": "event.birth.action.declare.form.section.child.field.dob.error",
+                        "id": "v2.event.birth.action.declare.form.section.child.field.dob.error",
                       },
                       "validator": {
                         "properties": {
@@ -214,7 +225,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "",
                     "description": "empty string",
-                    "id": "messages.emptyString",
+                    "id": "v2.messages.emptyString",
                   },
                   "type": "DIVIDER",
                 },
@@ -223,14 +234,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Place of delivery",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.child.field.placeOfBirth.label",
+                    "id": "v2.event.birth.action.declare.form.section.child.field.placeOfBirth.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "Health Institution",
                         "description": "Select item for Health Institution",
-                        "id": "form.field.label.healthInstitution",
+                        "id": "v2.form.field.label.healthInstitution",
                       },
                       "value": "HEALTH_FACILITY",
                     },
@@ -238,7 +249,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Residential address",
                         "description": "Select item for Private Home",
-                        "id": "form.field.label.privateHome",
+                        "id": "v2.form.field.label.privateHome",
                       },
                       "value": "PRIVATE_HOME",
                     },
@@ -246,7 +257,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Other",
                         "description": "Select item for Other location",
-                        "id": "form.field.label.otherInstitution",
+                        "id": "v2.form.field.label.otherInstitution",
                       },
                       "value": "OTHER",
                     },
@@ -268,6 +279,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -286,6 +300,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "HEALTH_FACILITY",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -300,6 +315,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -308,7 +325,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Health Institution",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.child.field.birthLocation.label",
+                    "id": "v2.event.birth.action.declare.form.section.child.field.birthLocation.label",
                   },
                   "options": {
                     "type": "HEALTH_FACILITY",
@@ -330,6 +347,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -348,6 +368,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -362,6 +383,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -370,7 +393,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Country",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.country.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.country.label",
                   },
                   "required": true,
                   "type": "COUNTRY",
@@ -389,6 +412,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -405,6 +431,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -419,6 +446,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -434,6 +463,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -452,6 +484,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -466,6 +499,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -474,7 +509,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "State",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.state.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.state.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -493,6 +528,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -509,6 +547,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -523,6 +562,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -538,6 +579,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -556,6 +600,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -570,6 +615,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -578,7 +625,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "District",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.district.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.district.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -597,6 +644,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -613,6 +663,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -627,6 +678,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -642,6 +695,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -660,6 +716,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -674,6 +731,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -682,7 +741,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "City / Town",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.town.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.town.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -701,6 +760,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -717,6 +779,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -731,6 +794,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -746,6 +811,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -764,6 +832,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -778,6 +847,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -786,7 +857,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 1",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine1.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine1.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -805,6 +876,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -821,6 +895,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -835,6 +910,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -850,6 +927,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -868,6 +948,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -882,6 +963,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -890,7 +973,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 2",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine2.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine2.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -909,6 +992,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -925,6 +1011,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -939,6 +1026,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -954,6 +1043,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -972,6 +1064,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -986,6 +1079,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -994,7 +1089,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 3",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine3.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine3.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -1013,6 +1108,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1029,6 +1127,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1043,6 +1142,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1058,6 +1159,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1076,6 +1180,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1090,6 +1195,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1098,7 +1205,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Postcode / Zip",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.zipCode.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.zipCode.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -1117,6 +1224,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1135,6 +1245,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1149,6 +1260,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1164,6 +1277,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1182,6 +1298,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1196,6 +1313,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1204,7 +1323,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Province",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.childResidentialAddress.field.address.province.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.province.label",
                   },
                   "options": {
                     "type": "ADMIN_STRUCTURE",
@@ -1226,6 +1345,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1244,6 +1366,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1258,6 +1381,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1273,6 +1398,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1291,6 +1419,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1305,6 +1434,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1313,7 +1444,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "District",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.childResidentialAddress.field.address.district.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.district.label",
                   },
                   "options": {
                     "partOf": {
@@ -1338,6 +1469,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1356,6 +1490,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1370,6 +1505,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1385,6 +1522,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1403,6 +1543,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1417,24 +1558,25 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
-                  "flexDirection": "row",
                   "hideLabel": true,
                   "id": "childResidentialAddress.address.urbanOrRural",
                   "label": {
                     "defaultMessage": "Urban or Rural",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.childResidentialAddress.field.address.urbanOrRural.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.urbanOrRural.label",
                   },
-                  "optionValues": [
+                  "options": [
                     {
                       "label": {
                         "defaultMessage": "Urban",
                         "description": "Label for form field checkbox option Urban",
-                        "id": "form.field.label.urban",
+                        "id": "v2.form.field.label.urban",
                       },
                       "value": "URBAN",
                     },
@@ -1442,12 +1584,11 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Rural",
                         "description": "Label for form field checkbox option Rural",
-                        "id": "form.field.label.rural",
+                        "id": "v2.form.field.label.rural",
                       },
                       "value": "RURAL",
                     },
                   ],
-                  "options": {},
                   "required": false,
                   "type": "RADIO_GROUP",
                 },
@@ -1465,6 +1606,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1481,6 +1625,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1495,6 +1640,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1510,6 +1657,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1528,6 +1678,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1542,6 +1693,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1557,6 +1710,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1575,6 +1731,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1589,6 +1746,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1597,7 +1756,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Town",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.town.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.town.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -1616,6 +1775,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1632,6 +1794,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1646,6 +1809,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1661,6 +1826,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1679,6 +1847,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1693,6 +1862,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1708,6 +1879,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1726,6 +1900,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1740,6 +1915,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1748,7 +1925,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Residential Area",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.residentialArea.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.residentialArea.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -1767,6 +1944,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1783,6 +1963,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1797,6 +1978,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1812,6 +1995,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1830,6 +2016,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1844,6 +2031,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1859,6 +2048,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1877,6 +2069,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1891,6 +2084,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1899,7 +2094,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Street",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.street.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.street.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -1918,6 +2113,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1934,6 +2132,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1948,6 +2147,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -1963,6 +2164,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -1981,6 +2185,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -1995,6 +2200,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2010,6 +2217,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2028,6 +2238,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2042,6 +2253,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2050,7 +2263,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Number",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.number.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.number.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -2069,6 +2282,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2085,6 +2301,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2099,6 +2316,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2114,6 +2333,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2132,6 +2354,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2146,6 +2369,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2161,6 +2386,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2179,6 +2407,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2193,6 +2422,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2201,7 +2432,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Postcode / Zip",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.zipCode.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.zipCode.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -2220,6 +2451,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2238,6 +2472,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "RURAL",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2252,6 +2487,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2267,6 +2504,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2285,6 +2525,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2299,6 +2540,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2314,6 +2557,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2332,6 +2578,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PRIVATE_HOME",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2346,6 +2593,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2354,7 +2603,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Village",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.childResidentialAddress.field.address.village.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.village.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -2373,6 +2622,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2391,6 +2643,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2405,6 +2658,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2413,7 +2668,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Country",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.country.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.country.label",
                   },
                   "required": true,
                   "type": "COUNTRY",
@@ -2432,6 +2687,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2448,6 +2706,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2462,6 +2721,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2477,6 +2738,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2495,6 +2759,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2509,6 +2774,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2517,7 +2784,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "State",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.state.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.state.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -2536,6 +2803,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2552,6 +2822,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2566,6 +2837,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2581,6 +2854,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2599,6 +2875,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2613,6 +2890,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2621,7 +2900,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "District",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.district.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.district.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -2640,6 +2919,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2656,6 +2938,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2670,6 +2953,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2685,6 +2970,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2703,6 +2991,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2717,6 +3006,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2725,7 +3016,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "City / Town",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.town.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.town.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -2744,6 +3035,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2760,6 +3054,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2774,6 +3069,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2789,6 +3086,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2807,6 +3107,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2821,6 +3122,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2829,7 +3132,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 1",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine1.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine1.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -2848,6 +3151,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2864,6 +3170,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2878,6 +3185,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2893,6 +3202,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2911,6 +3223,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2925,6 +3238,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2933,7 +3248,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 2",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine2.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine2.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -2952,6 +3267,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -2968,6 +3286,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -2982,6 +3301,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -2997,6 +3318,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3015,6 +3339,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3029,6 +3354,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3037,7 +3364,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 3",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine3.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine3.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -3056,6 +3383,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3072,6 +3402,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3086,6 +3417,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3101,6 +3434,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3119,6 +3455,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3133,6 +3470,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3141,7 +3480,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Postcode / Zip",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.zipCode.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.zipCode.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -3160,6 +3499,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3178,6 +3520,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3192,6 +3535,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3207,6 +3552,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3225,6 +3573,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3239,6 +3588,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3247,7 +3598,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Province",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.childOther.field.address.province.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.province.label",
                   },
                   "options": {
                     "type": "ADMIN_STRUCTURE",
@@ -3269,6 +3620,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3287,6 +3641,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3301,6 +3656,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3316,6 +3673,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3334,6 +3694,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3348,6 +3709,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3356,7 +3719,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "District",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.childOther.field.address.district.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.district.label",
                   },
                   "options": {
                     "partOf": {
@@ -3381,6 +3744,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3399,6 +3765,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3413,6 +3780,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3428,6 +3797,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3446,6 +3818,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3460,24 +3833,25 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
-                  "flexDirection": "row",
                   "hideLabel": true,
                   "id": "childOther.address.urbanOrRural",
                   "label": {
                     "defaultMessage": "Urban or Rural",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.childOther.field.address.urbanOrRural.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.urbanOrRural.label",
                   },
-                  "optionValues": [
+                  "options": [
                     {
                       "label": {
                         "defaultMessage": "Urban",
                         "description": "Label for form field checkbox option Urban",
-                        "id": "form.field.label.urban",
+                        "id": "v2.form.field.label.urban",
                       },
                       "value": "URBAN",
                     },
@@ -3485,12 +3859,11 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Rural",
                         "description": "Label for form field checkbox option Rural",
-                        "id": "form.field.label.rural",
+                        "id": "v2.form.field.label.rural",
                       },
                       "value": "RURAL",
                     },
                   ],
-                  "options": {},
                   "required": false,
                   "type": "RADIO_GROUP",
                 },
@@ -3508,6 +3881,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3524,6 +3900,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3538,6 +3915,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3553,6 +3932,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3571,6 +3953,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3585,6 +3968,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3600,6 +3985,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3618,6 +4006,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3632,6 +4021,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3640,7 +4031,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Town",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.town.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.town.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -3659,6 +4050,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3675,6 +4069,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3689,6 +4084,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3704,6 +4101,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3722,6 +4122,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3736,6 +4137,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3751,6 +4154,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3769,6 +4175,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3783,6 +4190,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3791,7 +4200,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Residential Area",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.residentialArea.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.residentialArea.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -3810,6 +4219,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3826,6 +4238,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3840,6 +4253,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3855,6 +4270,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3873,6 +4291,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3887,6 +4306,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3902,6 +4323,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3920,6 +4344,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3934,6 +4359,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -3942,7 +4369,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Street",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.street.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.street.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -3961,6 +4388,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -3977,6 +4407,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -3991,6 +4422,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4006,6 +4439,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4024,6 +4460,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4038,6 +4475,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4053,6 +4492,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4071,6 +4513,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4085,6 +4528,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4093,7 +4538,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Number",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.number.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.number.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -4112,6 +4557,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4128,6 +4576,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4142,6 +4591,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4157,6 +4608,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4175,6 +4629,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4189,6 +4644,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4204,6 +4661,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4222,6 +4682,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4236,6 +4697,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4244,7 +4707,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Postcode / Zip",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.zipCode.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.zipCode.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -4263,6 +4726,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4281,6 +4747,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "RURAL",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4295,6 +4762,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4310,6 +4779,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4328,6 +4800,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4342,6 +4815,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4357,6 +4832,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4375,6 +4853,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4389,6 +4868,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4397,7 +4878,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Village",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.childOther.field.address.village.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.village.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -4407,7 +4888,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "",
                     "description": "empty string",
-                    "id": "messages.emptyString",
+                    "id": "v2.messages.emptyString",
                   },
                   "type": "DIVIDER",
                 },
@@ -4416,14 +4897,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Attendant at birth",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.child.field.attendantAtBirth.label",
+                    "id": "v2.event.birth.action.declare.form.section.child.field.attendantAtBirth.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "Physician",
                         "description": "Label for physician attendant",
-                        "id": "form.field.label.attendantAtBirthPhysician",
+                        "id": "v2.form.field.label.attendantAtBirthPhysician",
                       },
                       "value": "PHYSICIAN",
                     },
@@ -4431,7 +4912,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Nurse",
                         "description": "Label for nurse attendant",
-                        "id": "form.field.label.attendantAtBirthNurse",
+                        "id": "v2.form.field.label.attendantAtBirthNurse",
                       },
                       "value": "NURSE",
                     },
@@ -4439,7 +4920,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Midwife",
                         "description": "Label for midwife attendant",
-                        "id": "form.field.label.attendantAtBirthMidwife",
+                        "id": "v2.form.field.label.attendantAtBirthMidwife",
                       },
                       "value": "MIDWIFE",
                     },
@@ -4447,7 +4928,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Other paramedical personnel",
                         "description": "Label for other paramedical personnel",
-                        "id": "form.field.label.attendantAtBirthOtherParamedicalPersonnel",
+                        "id": "v2.form.field.label.attendantAtBirthOtherParamedicalPersonnel",
                       },
                       "value": "OTHER_PARAMEDICAL_PERSONNEL",
                     },
@@ -4455,7 +4936,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Layperson",
                         "description": "Label for layperson attendant",
-                        "id": "form.field.label.attendantAtBirthLayperson",
+                        "id": "v2.form.field.label.attendantAtBirthLayperson",
                       },
                       "value": "LAYPERSON",
                     },
@@ -4463,7 +4944,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Traditional birth attendant",
                         "description": "Label for traditional birth attendant",
-                        "id": "form.field.label.attendantAtBirthTraditionalBirthAttendant",
+                        "id": "v2.form.field.label.attendantAtBirthTraditionalBirthAttendant",
                       },
                       "value": "TRADITIONAL_BIRTH_ATTENDANT",
                     },
@@ -4471,7 +4952,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "None",
                         "description": "Label for no attendant",
-                        "id": "form.field.label.attendantAtBirthNone",
+                        "id": "v2.form.field.label.attendantAtBirthNone",
                       },
                       "value": "NONE",
                     },
@@ -4484,14 +4965,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Type of birth",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.child.field.birthType.label",
+                    "id": "v2.event.birth.action.declare.form.section.child.field.birthType.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "Single",
                         "description": "Label for single birth",
-                        "id": "form.field.label.birthTypeSingle",
+                        "id": "v2.form.field.label.birthTypeSingle",
                       },
                       "value": "SINGLE",
                     },
@@ -4499,7 +4980,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Twin",
                         "description": "Label for twin birth",
-                        "id": "form.field.label.birthTypeTwin",
+                        "id": "v2.form.field.label.birthTypeTwin",
                       },
                       "value": "TWIN",
                     },
@@ -4507,7 +4988,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Triplet",
                         "description": "Label for triplet birth",
-                        "id": "form.field.label.birthTypeTriplet",
+                        "id": "v2.form.field.label.birthTypeTriplet",
                       },
                       "value": "TRIPLET",
                     },
@@ -4515,7 +4996,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Quadruplet",
                         "description": "Label for quadruplet birth",
-                        "id": "form.field.label.birthTypeQuadruplet",
+                        "id": "v2.form.field.label.birthTypeQuadruplet",
                       },
                       "value": "QUADRUPLET",
                     },
@@ -4523,7 +5004,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Higher multiple delivery",
                         "description": "Label for higher multiple delivery birth",
-                        "id": "form.field.label.birthTypeHigherMultipleDelivery",
+                        "id": "v2.form.field.label.birthTypeHigherMultipleDelivery",
                       },
                       "value": "HIGHER_MULTIPLE_DELIVERY",
                     },
@@ -4532,19 +5013,19 @@ exports[`birth configuration is parsed 1`] = `
                   "type": "SELECT",
                 },
                 {
+                  "configuration": {
+                    "postfix": {
+                      "defaultMessage": "Kilograms (kg)",
+                      "description": "This is the postfix for the weight field",
+                      "id": "v2.event.birth.action.declare.form.section.child.field.weightAtBirth.postfix",
+                    },
+                    "type": "number",
+                  },
                   "id": "child.weightAtBirth",
                   "label": {
                     "defaultMessage": "Weight at birth",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.child.field.weightAtBirth.label",
-                  },
-                  "options": {
-                    "postfix": {
-                      "defaultMessage": "Kilograms (kg)",
-                      "description": "This is the postfix for the weight field",
-                      "id": "event.birth.action.declare.form.section.child.field.weightAtBirth.postfix",
-                    },
-                    "type": "number",
+                    "id": "v2.event.birth.action.declare.form.section.child.field.weightAtBirth.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -4554,7 +5035,7 @@ exports[`birth configuration is parsed 1`] = `
               "title": {
                 "defaultMessage": "Child's details",
                 "description": "Form section title for Child",
-                "id": "form.birth.child.title",
+                "id": "v2.form.birth.child.title",
               },
             },
             {
@@ -4564,14 +5045,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Relationship to child",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.relation.label",
+                    "id": "v2.event.birth.action.declare.form.section.informant.field.relation.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "Mother",
                         "description": "Label for option mother",
-                        "id": "form.field.label.informantRelation.mother",
+                        "id": "v2.form.field.label.informantRelation.mother",
                       },
                       "value": "MOTHER",
                     },
@@ -4579,7 +5060,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Father",
                         "description": "Label for option father",
-                        "id": "form.field.label.informantRelation.father",
+                        "id": "v2.form.field.label.informantRelation.father",
                       },
                       "value": "FATHER",
                     },
@@ -4587,7 +5068,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Someone else",
                         "description": "Label for option someone else",
-                        "id": "form.field.label.informantRelation.others",
+                        "id": "v2.form.field.label.informantRelation.others",
                       },
                       "value": "OTHER",
                     },
@@ -4595,7 +5076,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Grandfather",
                         "description": "Label for option Grandfather",
-                        "id": "form.field.label.informantRelation.grandfather",
+                        "id": "v2.form.field.label.informantRelation.grandfather",
                       },
                       "value": "GRANDFATHER",
                     },
@@ -4603,7 +5084,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Grandmother",
                         "description": "Label for option Grandmother",
-                        "id": "form.field.label.informantRelation.grandmother",
+                        "id": "v2.form.field.label.informantRelation.grandmother",
                       },
                       "value": "GRANDMOTHER",
                     },
@@ -4611,7 +5092,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Brother",
                         "description": "Label for option brother",
-                        "id": "form.field.label.informantRelation.brother",
+                        "id": "v2.form.field.label.informantRelation.brother",
                       },
                       "value": "BROTHER",
                     },
@@ -4619,7 +5100,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Sister",
                         "description": "Label for option Sister",
-                        "id": "form.field.label.informantRelation.sister",
+                        "id": "v2.form.field.label.informantRelation.sister",
                       },
                       "value": "SISTER",
                     },
@@ -4627,7 +5108,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Legal guardian",
                         "description": "Label for option Legal Guardian",
-                        "id": "form.field.label.informantRelation.legalGuardian",
+                        "id": "v2.form.field.label.informantRelation.legalGuardian",
                       },
                       "value": "LEGAL_GUARDIAN",
                     },
@@ -4649,6 +5130,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4667,6 +5151,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "OTHER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4681,6 +5166,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4689,7 +5176,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Relationship to child",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.other.relation.label",
+                    "id": "v2.event.birth.action.declare.form.section.informant.field.other.relation.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -4708,6 +5195,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4725,6 +5215,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4739,6 +5230,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4747,7 +5240,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "First name(s)",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.firstname.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.firstname.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -4766,6 +5259,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4783,6 +5279,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4797,6 +5294,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4805,7 +5304,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Last name",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.surname.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.surname.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -4819,6 +5318,7 @@ exports[`birth configuration is parsed 1`] = `
                             "properties": {
                               "informant.dobUnknown": {
                                 "const": "true",
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -4846,6 +5346,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4863,6 +5366,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4877,6 +5381,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4885,7 +5391,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Date of birth",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.dob.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.dob.label",
                   },
                   "required": true,
                   "type": "DATE",
@@ -4894,7 +5400,7 @@ exports[`birth configuration is parsed 1`] = `
                       "message": {
                         "defaultMessage": "Please enter a valid date",
                         "description": "This is the error message for invalid date",
-                        "id": "event.birth.action.declare.form.section.informant.field.dob.error",
+                        "id": "v2.event.birth.action.declare.form.section.person.field.dob.error",
                       },
                       "validator": {
                         "properties": {
@@ -4941,6 +5447,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -4958,6 +5467,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -4972,6 +5482,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -4980,7 +5492,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Exact date of birth unknown",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.age.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.age.checkbox.label",
                   },
                   "required": true,
                   "type": "CHECKBOX",
@@ -4999,6 +5511,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5015,6 +5530,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "false",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5029,6 +5545,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5044,6 +5562,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5061,6 +5582,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5075,22 +5597,24 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
+                  "configuration": {
+                    "postfix": {
+                      "defaultMessage": "years",
+                      "description": "This is the postfix for age field",
+                      "id": "v2.event.birth.action.declare.form.section.person.field.age.postfix",
+                    },
+                  },
                   "id": "informant.age",
                   "label": {
                     "defaultMessage": "Age of informant",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.age.label",
-                  },
-                  "options": {
-                    "postfix": {
-                      "defaultMessage": "years",
-                      "description": "This is the postfix for age field",
-                      "id": "event.birth.action.declare.form.section.informant.field.age.postfix",
-                    },
+                    "id": "v2.event.birth.action.declare.form.section.person.field.age.text.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -5109,6 +5633,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5126,6 +5653,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5140,6 +5668,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5148,7 +5678,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Nationality",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.nationality.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.nationality.label",
                   },
                   "required": true,
                   "type": "COUNTRY",
@@ -5167,6 +5697,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5184,6 +5717,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5198,6 +5732,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5206,14 +5742,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Type of ID",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.idType.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.idType.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "National ID",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypeNationalID",
+                        "id": "v2.form.field.label.iDTypeNationalID",
                       },
                       "value": "NATIONAL_ID",
                     },
@@ -5221,7 +5757,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Passport",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypePassport",
+                        "id": "v2.form.field.label.iDTypePassport",
                       },
                       "value": "PASSPORT",
                     },
@@ -5229,7 +5765,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Birth Registration Number",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypeBRN",
+                        "id": "v2.form.field.label.iDTypeBRN",
                       },
                       "value": "BIRTH_REGISTRATION_NUMBER",
                     },
@@ -5237,7 +5773,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "None",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypeNone",
+                        "id": "v2.form.field.label.iDTypeNone",
                       },
                       "value": "NONE",
                     },
@@ -5259,6 +5795,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5277,6 +5816,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "NATIONAL_ID",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5291,6 +5831,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5306,6 +5848,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5323,6 +5868,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5337,6 +5883,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5345,7 +5893,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "ID Number",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.nid.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.nid.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -5364,6 +5912,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5382,6 +5933,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PASSPORT",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5396,6 +5948,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5411,6 +5965,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5428,6 +5985,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5442,6 +6000,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5450,7 +6010,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "ID Number",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.passport.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.passport.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -5469,6 +6029,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5487,6 +6050,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "BIRTH_REGISTRATION_NUMBER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5501,6 +6065,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5516,6 +6082,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5533,6 +6102,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5547,6 +6117,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5555,7 +6127,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "ID Number",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.brn.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.brn.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -5574,6 +6146,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5591,6 +6166,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5605,6 +6181,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5613,7 +6191,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "",
                     "description": "empty string",
-                    "id": "messages.emptyString",
+                    "id": "v2.messages.emptyString",
                   },
                   "type": "DIVIDER",
                 },
@@ -5631,6 +6209,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5648,6 +6229,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5662,18 +6244,22 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
+                  "configuration": {
+                    "styles": {
+                      "fontVariant": "h3",
+                    },
+                  },
                   "id": "informant.addressHelper",
                   "label": {
                     "defaultMessage": "Usual place of residence",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.addressHelper.label",
-                  },
-                  "options": {
-                    "fontVariant": "h3",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.addressHelper.label",
                   },
                   "type": "PARAGRAPH",
                 },
@@ -5691,6 +6277,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5708,6 +6297,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5722,6 +6312,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5730,7 +6322,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Country",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.country.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.country.label",
                   },
                   "required": true,
                   "type": "COUNTRY",
@@ -5749,6 +6341,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5765,6 +6360,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5779,6 +6375,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5794,6 +6392,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5811,6 +6412,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5825,6 +6427,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5833,7 +6437,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "State",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.state.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.state.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -5852,6 +6456,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5868,6 +6475,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5882,6 +6490,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5897,6 +6507,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5914,6 +6527,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5928,6 +6542,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -5936,7 +6552,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "District",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.district.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.district.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -5955,6 +6571,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -5971,6 +6590,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -5985,6 +6605,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6000,6 +6622,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6017,6 +6642,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6031,6 +6657,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6039,7 +6667,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "City / Town",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.town.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.town.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -6058,6 +6686,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6074,6 +6705,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6088,6 +6720,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6103,6 +6737,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6120,6 +6757,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6134,6 +6772,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6142,7 +6782,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 1",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine1.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine1.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -6161,6 +6801,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6177,6 +6820,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6191,6 +6835,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6206,6 +6852,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6223,6 +6872,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6237,6 +6887,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6245,7 +6897,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 2",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine2.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine2.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -6264,6 +6916,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6280,6 +6935,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6294,6 +6950,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6309,6 +6967,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6326,6 +6987,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6340,6 +7002,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6348,7 +7012,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 3",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine3.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine3.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -6367,6 +7031,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6383,6 +7050,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6397,6 +7065,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6412,6 +7082,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6429,6 +7102,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6443,6 +7117,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6451,7 +7127,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Postcode / Zip",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.zipCode.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.zipCode.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -6470,6 +7146,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6488,6 +7167,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6502,6 +7182,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6517,6 +7199,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6534,6 +7219,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6548,6 +7234,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6556,7 +7244,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Province",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.address.province.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.province.label",
                   },
                   "options": {
                     "type": "ADMIN_STRUCTURE",
@@ -6578,6 +7266,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6596,6 +7287,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6610,6 +7302,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6625,6 +7319,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6642,6 +7339,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6656,6 +7354,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6664,7 +7364,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "District",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.address.district.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.district.label",
                   },
                   "options": {
                     "partOf": {
@@ -6689,6 +7389,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6707,6 +7410,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6721,6 +7425,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6736,6 +7442,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6753,6 +7462,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6767,24 +7477,25 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
-                  "flexDirection": "row",
                   "hideLabel": true,
                   "id": "informant.address.urbanOrRural",
                   "label": {
                     "defaultMessage": "Urban or Rural",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.address.urbanOrRural.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.urbanOrRural.label",
                   },
-                  "optionValues": [
+                  "options": [
                     {
                       "label": {
                         "defaultMessage": "Urban",
                         "description": "Label for form field checkbox option Urban",
-                        "id": "form.field.label.urban",
+                        "id": "v2.form.field.label.urban",
                       },
                       "value": "URBAN",
                     },
@@ -6792,12 +7503,11 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Rural",
                         "description": "Label for form field checkbox option Rural",
-                        "id": "form.field.label.rural",
+                        "id": "v2.form.field.label.rural",
                       },
                       "value": "RURAL",
                     },
                   ],
-                  "options": {},
                   "required": false,
                   "type": "RADIO_GROUP",
                 },
@@ -6815,6 +7525,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6831,6 +7544,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6845,6 +7559,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6860,6 +7576,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6878,6 +7597,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6892,6 +7612,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6907,6 +7629,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6924,6 +7649,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6938,6 +7664,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -6946,7 +7674,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Town",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.town.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.town.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -6965,6 +7693,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -6981,6 +7712,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -6995,6 +7727,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7010,6 +7744,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7028,6 +7765,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7042,6 +7780,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7057,6 +7797,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7074,6 +7817,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7088,6 +7832,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7096,7 +7842,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Residential Area",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.residentialArea.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.residentialArea.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -7115,6 +7861,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7131,6 +7880,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7145,6 +7895,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7160,6 +7912,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7178,6 +7933,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7192,6 +7948,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7207,6 +7965,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7224,6 +7985,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7238,6 +8000,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7246,7 +8010,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Street",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.street.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.street.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -7265,6 +8029,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7281,6 +8048,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7295,6 +8063,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7310,6 +8080,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7328,6 +8101,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7342,6 +8116,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7357,6 +8133,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7374,6 +8153,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7388,6 +8168,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7396,7 +8178,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Number",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.number.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.number.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -7415,6 +8197,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7431,6 +8216,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7445,6 +8231,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7460,6 +8248,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7478,6 +8269,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7492,6 +8284,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7507,6 +8301,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7524,6 +8321,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7538,6 +8336,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7546,7 +8346,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Postcode / Zip",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.zipCode.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.zipCode.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -7565,6 +8365,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7583,6 +8386,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "RURAL",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7597,6 +8401,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7612,6 +8418,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7630,6 +8439,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7644,6 +8454,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7659,6 +8471,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7676,6 +8491,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7690,6 +8506,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -7698,7 +8516,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Village",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.address.village.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.village.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -7717,6 +8535,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -7734,6 +8555,7 @@ exports[`birth configuration is parsed 1`] = `
                                       "MOTHER",
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7748,15 +8570,17 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
-                  "id": "informant.address.divider.end",
+                  "id": "v2.informant.address.divider.end",
                   "label": {
                     "defaultMessage": "",
                     "description": "empty string",
-                    "id": "messages.emptyString",
+                    "id": "v2.messages.emptyString",
                   },
                   "type": "DIVIDER",
                 },
@@ -7765,20 +8589,20 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Phone number",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.phoneNo.label",
+                    "id": "v2.event.birth.action.declare.form.section.informant.field.phoneNo.label",
                   },
                   "required": false,
                   "type": "TEXT",
                 },
                 {
+                  "configuration": {
+                    "type": "email",
+                  },
                   "id": "informant.email",
                   "label": {
                     "defaultMessage": "Email",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.informant.field.email.label",
-                  },
-                  "options": {
-                    "type": "email",
+                    "id": "v2.event.birth.action.declare.form.section.informant.field.email.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -7788,7 +8612,7 @@ exports[`birth configuration is parsed 1`] = `
               "title": {
                 "defaultMessage": "Informant's details",
                 "description": "Form section title for informants details",
-                "id": "form.section.informant.title",
+                "id": "v2.form.section.informant.title",
               },
             },
             {
@@ -7804,6 +8628,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "MOTHER",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -7840,6 +8665,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "MOTHER",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -7860,7 +8686,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "",
                     "description": "empty string",
-                    "id": "messages.emptyString",
+                    "id": "v2.messages.emptyString",
                   },
                   "type": "DIVIDER",
                 },
@@ -7880,6 +8706,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -7896,6 +8725,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "enum": [
                                           "false",
                                         ],
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -7910,6 +8740,8 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                           {
                             "properties": {
@@ -7919,6 +8751,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "MOTHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7933,6 +8766,7 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -7942,7 +8776,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Reason",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.reason.label",
+                    "id": "v2.event.birth.action.declare.form.section.mother.field.reason.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -7960,6 +8794,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -7984,6 +8819,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -8002,6 +8840,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -8016,8 +8855,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -8027,7 +8869,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "First name(s)",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.firstname.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.firstname.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -8045,6 +8887,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8069,6 +8912,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -8087,6 +8933,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -8101,8 +8948,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -8112,7 +8962,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Last name",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.surname.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.surname.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -8126,6 +8976,7 @@ exports[`birth configuration is parsed 1`] = `
                             "properties": {
                               "mother.dobUnknown": {
                                 "const": "true",
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -8152,6 +9003,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8176,6 +9028,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -8194,6 +9049,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -8208,8 +9064,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -8219,7 +9078,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Date of birth",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.dob.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.dob.label",
                   },
                   "required": true,
                   "type": "DATE",
@@ -8228,7 +9087,7 @@ exports[`birth configuration is parsed 1`] = `
                       "message": {
                         "defaultMessage": "Please enter a valid date",
                         "description": "This is the error message for invalid date",
-                        "id": "event.birth.action.declare.form.section.mother.field.dob.error",
+                        "id": "v2.event.birth.action.declare.form.section.person.field.dob.error",
                       },
                       "validator": {
                         "properties": {
@@ -8274,6 +9133,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8298,6 +9158,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -8316,6 +9179,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -8330,8 +9194,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -8341,7 +9208,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Exact date of birth unknown",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.age.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.age.checkbox.label",
                   },
                   "required": true,
                   "type": "CHECKBOX",
@@ -8360,6 +9227,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -8376,6 +9246,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "false",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8390,6 +9261,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -8404,6 +9277,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8428,6 +9302,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -8446,6 +9323,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -8460,25 +9338,28 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
+                  "configuration": {
+                    "postfix": {
+                      "defaultMessage": "years",
+                      "description": "This is the postfix for age field",
+                      "id": "v2.event.birth.action.declare.form.section.person.field.age.postfix",
+                    },
+                  },
                   "id": "mother.age",
                   "label": {
                     "defaultMessage": "Age of mother",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.age.label",
-                  },
-                  "options": {
-                    "postfix": {
-                      "defaultMessage": "years",
-                      "description": "This is the postfix for age field",
-                      "id": "event.birth.action.declare.form.section.mother.field.age.postfix",
-                    },
+                    "id": "v2.event.birth.action.declare.form.section.person.field.age.text.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -8496,6 +9377,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8520,6 +9402,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -8538,6 +9423,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -8552,8 +9438,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -8563,7 +9452,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Nationality",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.nationality.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.nationality.label",
                   },
                   "required": true,
                   "type": "COUNTRY",
@@ -8581,6 +9470,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8605,6 +9495,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -8623,6 +9516,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -8637,8 +9531,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -8648,14 +9545,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Type of ID",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.idType.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.idType.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "National ID",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypeNationalID",
+                        "id": "v2.form.field.label.iDTypeNationalID",
                       },
                       "value": "NATIONAL_ID",
                     },
@@ -8663,7 +9560,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Passport",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypePassport",
+                        "id": "v2.form.field.label.iDTypePassport",
                       },
                       "value": "PASSPORT",
                     },
@@ -8671,7 +9568,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Birth Registration Number",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypeBRN",
+                        "id": "v2.form.field.label.iDTypeBRN",
                       },
                       "value": "BIRTH_REGISTRATION_NUMBER",
                     },
@@ -8679,7 +9576,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "None",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypeNone",
+                        "id": "v2.form.field.label.iDTypeNone",
                       },
                       "value": "NONE",
                     },
@@ -8701,6 +9598,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -8719,6 +9619,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "NATIONAL_ID",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8733,6 +9634,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -8747,6 +9650,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8771,6 +9675,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -8789,6 +9696,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -8803,8 +9711,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -8814,7 +9725,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "ID Number",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.nid.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.nid.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -8833,6 +9744,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -8851,6 +9765,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PASSPORT",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8865,6 +9780,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -8879,6 +9796,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8903,6 +9821,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -8921,6 +9842,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -8935,8 +9857,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -8946,7 +9871,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "ID Number",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.passport.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.passport.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -8965,6 +9890,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -8983,6 +9911,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "BIRTH_REGISTRATION_NUMBER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -8997,6 +9926,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -9011,6 +9942,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9035,6 +9967,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -9053,6 +9988,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -9067,8 +10003,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -9078,7 +10017,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "ID Number",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.brn.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.brn.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -9096,6 +10035,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9120,6 +10060,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -9138,6 +10081,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -9152,8 +10096,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -9163,7 +10110,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "",
                     "description": "empty string",
-                    "id": "messages.emptyString",
+                    "id": "v2.messages.emptyString",
                   },
                   "type": "DIVIDER",
                 },
@@ -9180,6 +10127,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9204,6 +10152,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -9222,6 +10173,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -9236,21 +10188,26 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
+                  "configuration": {
+                    "styles": {
+                      "fontVariant": "h3",
+                    },
+                  },
                   "id": "mother.addressHelper",
                   "label": {
                     "defaultMessage": "Usual place of residence",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.addressHelper.label",
-                  },
-                  "options": {
-                    "fontVariant": "h3",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.addressHelper.label",
                   },
                   "type": "PARAGRAPH",
                 },
@@ -9267,6 +10224,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9291,6 +10249,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -9309,6 +10270,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -9323,8 +10285,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -9334,7 +10299,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Country",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.country.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.country.label",
                   },
                   "required": true,
                   "type": "COUNTRY",
@@ -9353,6 +10318,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -9369,6 +10337,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9383,6 +10352,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -9397,6 +10368,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9421,6 +10393,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -9439,6 +10414,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -9453,8 +10429,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -9464,7 +10443,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "State",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.state.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.state.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -9483,6 +10462,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -9499,6 +10481,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9513,6 +10496,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -9527,6 +10512,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9551,6 +10537,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -9569,6 +10558,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -9583,8 +10573,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -9594,7 +10587,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "District",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.district.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.district.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -9613,6 +10606,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -9629,6 +10625,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9643,6 +10640,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -9657,6 +10656,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9681,6 +10681,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -9699,6 +10702,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -9713,8 +10717,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -9724,7 +10731,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "City / Town",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.town.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.town.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -9743,6 +10750,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -9759,6 +10769,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9773,6 +10784,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -9787,6 +10800,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9811,6 +10825,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -9829,6 +10846,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -9843,8 +10861,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -9854,7 +10875,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 1",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine1.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine1.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -9873,6 +10894,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -9889,6 +10913,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9903,6 +10928,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -9917,6 +10944,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -9941,6 +10969,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -9959,6 +10990,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -9973,8 +11005,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -9984,7 +11019,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 2",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine2.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine2.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -10003,6 +11038,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -10019,6 +11057,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10033,6 +11072,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -10047,6 +11088,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10071,6 +11113,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -10089,6 +11134,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -10103,8 +11149,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -10114,7 +11163,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 3",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine3.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine3.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -10133,6 +11182,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -10149,6 +11201,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10163,6 +11216,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -10177,6 +11232,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10201,6 +11257,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -10219,6 +11278,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -10233,8 +11293,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -10244,7 +11307,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Postcode / Zip",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.zipCode.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.zipCode.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -10263,6 +11326,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -10281,6 +11347,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10295,6 +11362,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -10309,6 +11378,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10333,6 +11403,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -10351,6 +11424,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -10365,8 +11439,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -10376,7 +11453,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Province",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.address.province.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.province.label",
                   },
                   "options": {
                     "type": "ADMIN_STRUCTURE",
@@ -10398,6 +11475,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -10416,6 +11496,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10430,6 +11511,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -10444,6 +11527,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10468,6 +11552,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -10486,6 +11573,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -10500,8 +11588,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -10511,7 +11602,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "District",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.address.district.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.district.label",
                   },
                   "options": {
                     "partOf": {
@@ -10536,6 +11627,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -10554,6 +11648,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10568,6 +11663,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -10582,6 +11679,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10606,6 +11704,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -10624,6 +11725,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -10638,27 +11740,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
-                  "flexDirection": "row",
                   "hideLabel": true,
                   "id": "mother.address.urbanOrRural",
                   "label": {
                     "defaultMessage": "Urban or Rural",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.address.urbanOrRural.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.urbanOrRural.label",
                   },
-                  "optionValues": [
+                  "options": [
                     {
                       "label": {
                         "defaultMessage": "Urban",
                         "description": "Label for form field checkbox option Urban",
-                        "id": "form.field.label.urban",
+                        "id": "v2.form.field.label.urban",
                       },
                       "value": "URBAN",
                     },
@@ -10666,12 +11770,11 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Rural",
                         "description": "Label for form field checkbox option Rural",
-                        "id": "form.field.label.rural",
+                        "id": "v2.form.field.label.rural",
                       },
                       "value": "RURAL",
                     },
                   ],
-                  "options": {},
                   "required": false,
                   "type": "RADIO_GROUP",
                 },
@@ -10689,6 +11792,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -10705,6 +11811,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10719,6 +11826,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -10734,6 +11843,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -10752,6 +11864,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10766,6 +11879,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -10780,6 +11895,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10804,6 +11920,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -10822,6 +11941,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -10836,8 +11956,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -10847,7 +11970,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Town",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.town.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.town.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -10866,6 +11989,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -10882,6 +12008,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10896,6 +12023,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -10911,6 +12040,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -10929,6 +12061,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10943,6 +12076,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -10957,6 +12092,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -10981,6 +12117,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -10999,6 +12138,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -11013,8 +12153,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -11024,7 +12167,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Residential Area",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.residentialArea.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.residentialArea.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -11043,6 +12186,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -11059,6 +12205,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11073,6 +12220,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -11088,6 +12237,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -11106,6 +12258,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11120,6 +12273,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -11134,6 +12289,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11158,6 +12314,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -11176,6 +12335,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -11190,8 +12350,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -11201,7 +12364,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Street",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.street.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.street.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -11220,6 +12383,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -11236,6 +12402,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11250,6 +12417,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -11265,6 +12434,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -11283,6 +12455,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11297,6 +12470,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -11311,6 +12486,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11335,6 +12511,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -11353,6 +12532,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -11367,8 +12547,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -11378,7 +12561,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Number",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.number.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.number.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -11397,6 +12580,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -11413,6 +12599,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11427,6 +12614,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -11442,6 +12631,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -11460,6 +12652,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11474,6 +12667,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -11488,6 +12683,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11512,6 +12708,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -11530,6 +12729,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -11544,8 +12744,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -11555,7 +12758,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Postcode / Zip",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.zipCode.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.zipCode.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -11574,6 +12777,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -11592,6 +12798,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "RURAL",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11606,6 +12813,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -11621,6 +12830,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -11639,6 +12851,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11653,6 +12866,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -11667,6 +12882,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11691,6 +12907,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -11709,6 +12928,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -11723,8 +12943,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -11734,7 +12957,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Village",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.address.village.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.village.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -11752,6 +12975,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11776,6 +13000,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -11794,6 +13021,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -11808,8 +13036,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -11819,7 +13050,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "",
                     "description": "empty string",
-                    "id": "messages.emptyString",
+                    "id": "v2.messages.emptyString",
                   },
                   "type": "DIVIDER",
                 },
@@ -11836,6 +13067,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11860,6 +13092,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -11878,6 +13113,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -11892,8 +13128,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -11903,14 +13142,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Marital Status",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.maritalStatus.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.maritalStatus.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "Single",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusSingle",
+                        "id": "v2.form.field.label.maritalStatusSingle",
                       },
                       "value": "SINGLE",
                     },
@@ -11918,7 +13157,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Married",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusMarried",
+                        "id": "v2.form.field.label.maritalStatusMarried",
                       },
                       "value": "MARRIED",
                     },
@@ -11926,7 +13165,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Widowed",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusWidowed",
+                        "id": "v2.form.field.label.maritalStatusWidowed",
                       },
                       "value": "WIDOWED",
                     },
@@ -11934,7 +13173,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Divorced",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusDivorced",
+                        "id": "v2.form.field.label.maritalStatusDivorced",
                       },
                       "value": "DIVORCED",
                     },
@@ -11942,7 +13181,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Separated",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusSeparated",
+                        "id": "v2.form.field.label.maritalStatusSeparated",
                       },
                       "value": "SEPARATED",
                     },
@@ -11950,7 +13189,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Not stated",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusNotStated",
+                        "id": "v2.form.field.label.maritalStatusNotStated",
                       },
                       "value": "NOT_STATED",
                     },
@@ -11971,6 +13210,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -11995,6 +13235,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -12013,6 +13256,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -12027,8 +13271,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -12038,14 +13285,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Level of education",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.educationalAttainment.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.educationalAttainment.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "No schooling",
                         "description": "Option for form field: no education",
-                        "id": "form.field.label.educationAttainmentNone",
+                        "id": "v2.form.field.label.educationAttainmentNone",
                       },
                       "value": "NO_SCHOOLING",
                     },
@@ -12053,7 +13300,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Primary",
                         "description": "Option for form field: ISCED1 education",
-                        "id": "form.field.label.educationAttainmentISCED1",
+                        "id": "v2.form.field.label.educationAttainmentISCED1",
                       },
                       "value": "PRIMARY_ISCED_1",
                     },
@@ -12061,7 +13308,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Secondary",
                         "description": "Option for form field: ISCED4 education",
-                        "id": "form.field.label.educationAttainmentISCED4",
+                        "id": "v2.form.field.label.educationAttainmentISCED4",
                       },
                       "value": "POST_SECONDARY_ISCED_4",
                     },
@@ -12069,7 +13316,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Tertiary",
                         "description": "Option for form field: ISCED5 education",
-                        "id": "form.field.label.educationAttainmentISCED5",
+                        "id": "v2.form.field.label.educationAttainmentISCED5",
                       },
                       "value": "FIRST_STAGE_TERTIARY_ISCED_5",
                     },
@@ -12090,6 +13337,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -12114,6 +13362,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -12132,6 +13383,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -12146,8 +13398,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -12157,7 +13412,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Occupation",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.occupation.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.occupation.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -12175,6 +13430,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -12199,6 +13455,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -12217,6 +13476,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "MOTHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -12231,8 +13491,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -12242,7 +13505,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "No. of previous births",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.mother.field.previousBirths.label",
+                    "id": "v2.event.birth.action.declare.form.section.mother.field.previousBirths.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -12252,7 +13515,7 @@ exports[`birth configuration is parsed 1`] = `
               "title": {
                 "defaultMessage": "Mother's details",
                 "description": "Form section title for mothers details",
-                "id": "form.section.mother.title",
+                "id": "v2.form.section.mother.title",
               },
             },
             {
@@ -12268,6 +13531,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "FATHER",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -12304,6 +13568,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "FATHER",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -12324,7 +13589,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "",
                     "description": "empty string",
-                    "id": "messages.emptyString",
+                    "id": "v2.messages.emptyString",
                   },
                   "type": "DIVIDER",
                 },
@@ -12344,6 +13609,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -12360,6 +13628,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "enum": [
                                           "false",
                                         ],
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -12374,6 +13643,8 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                           {
                             "properties": {
@@ -12383,6 +13654,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FATHER",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -12397,6 +13669,7 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -12406,7 +13679,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Reason",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.reason.label",
+                    "id": "v2.event.birth.action.declare.form.section.father.field.reason.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -12424,6 +13697,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -12448,6 +13722,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -12466,6 +13743,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -12480,8 +13758,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -12491,7 +13772,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "First name(s)",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.firstname.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.firstname.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -12509,6 +13790,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -12533,6 +13815,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -12551,6 +13836,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -12565,8 +13851,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -12576,7 +13865,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Last name",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.surname.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.surname.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -12590,6 +13879,7 @@ exports[`birth configuration is parsed 1`] = `
                             "properties": {
                               "father.dobUnknown": {
                                 "const": "true",
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -12616,6 +13906,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -12640,6 +13931,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -12658,6 +13952,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -12672,8 +13967,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -12683,7 +13981,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Date of birth",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.dob.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.dob.label",
                   },
                   "required": true,
                   "type": "DATE",
@@ -12692,7 +13990,7 @@ exports[`birth configuration is parsed 1`] = `
                       "message": {
                         "defaultMessage": "Please enter a valid date",
                         "description": "This is the error message for invalid date",
-                        "id": "event.birth.action.declare.form.section.father.field.dob.error",
+                        "id": "v2.event.birth.action.declare.form.section.person.field.dob.error",
                       },
                       "validator": {
                         "properties": {
@@ -12738,6 +14036,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -12762,6 +14061,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -12780,6 +14082,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -12794,8 +14097,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -12805,7 +14111,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Exact date of birth unknown",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.age.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.age.checkbox.label",
                   },
                   "required": true,
                   "type": "CHECKBOX",
@@ -12824,6 +14130,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -12840,6 +14149,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "false",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -12854,6 +14164,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -12868,6 +14180,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -12892,6 +14205,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -12910,6 +14226,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -12924,25 +14241,28 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
+                  "configuration": {
+                    "postfix": {
+                      "defaultMessage": "years",
+                      "description": "This is the postfix for age field",
+                      "id": "v2.event.birth.action.declare.form.section.person.field.age.postfix",
+                    },
+                  },
                   "id": "father.age",
                   "label": {
                     "defaultMessage": "Age of father",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.age.label",
-                  },
-                  "options": {
-                    "postfix": {
-                      "defaultMessage": "years",
-                      "description": "This is the postfix for age field",
-                      "id": "event.birth.action.declare.form.section.father.field.age.postfix",
-                    },
+                    "id": "v2.event.birth.action.declare.form.section.person.field.age.text.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -12960,6 +14280,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -12984,6 +14305,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -13002,6 +14326,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -13016,8 +14341,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -13027,7 +14355,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Nationality",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.nationality.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.nationality.label",
                   },
                   "required": true,
                   "type": "COUNTRY",
@@ -13045,6 +14373,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13069,6 +14398,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -13087,6 +14419,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -13101,8 +14434,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -13112,14 +14448,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Type of ID",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.idType.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.idType.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "National ID",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypeNationalID",
+                        "id": "v2.form.field.label.iDTypeNationalID",
                       },
                       "value": "NATIONAL_ID",
                     },
@@ -13127,7 +14463,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Passport",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypePassport",
+                        "id": "v2.form.field.label.iDTypePassport",
                       },
                       "value": "PASSPORT",
                     },
@@ -13135,7 +14471,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Birth Registration Number",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypeBRN",
+                        "id": "v2.form.field.label.iDTypeBRN",
                       },
                       "value": "BIRTH_REGISTRATION_NUMBER",
                     },
@@ -13143,7 +14479,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "None",
                         "description": "Option for form field: Type of ID",
-                        "id": "form.field.label.iDTypeNone",
+                        "id": "v2.form.field.label.iDTypeNone",
                       },
                       "value": "NONE",
                     },
@@ -13165,6 +14501,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -13183,6 +14522,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "NATIONAL_ID",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13197,6 +14537,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -13211,6 +14553,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13235,6 +14578,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -13253,6 +14599,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -13267,8 +14614,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -13278,7 +14628,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "ID Number",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.nid.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.nid.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -13297,6 +14647,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -13315,6 +14668,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "PASSPORT",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13329,6 +14683,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -13343,6 +14699,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13367,6 +14724,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -13385,6 +14745,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -13399,8 +14760,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -13410,7 +14774,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "ID Number",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.passport.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.passport.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -13429,6 +14793,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -13447,6 +14814,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "BIRTH_REGISTRATION_NUMBER",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13461,6 +14829,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -13475,6 +14845,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13499,6 +14870,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -13517,6 +14891,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -13531,8 +14906,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -13542,7 +14920,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "ID Number",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.brn.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.brn.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -13560,6 +14938,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13584,6 +14963,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -13602,6 +14984,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -13616,8 +14999,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -13627,7 +15013,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "",
                     "description": "empty string",
-                    "id": "messages.emptyString",
+                    "id": "v2.messages.emptyString",
                   },
                   "type": "DIVIDER",
                 },
@@ -13644,6 +15030,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13668,6 +15055,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -13686,6 +15076,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -13700,21 +15091,26 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
+                  "configuration": {
+                    "styles": {
+                      "fontVariant": "h3",
+                    },
+                  },
                   "id": "father.addressHelper",
                   "label": {
                     "defaultMessage": "Usual place of residence",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.addressHelper.label",
-                  },
-                  "options": {
-                    "fontVariant": "h3",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.addressHelper.label",
                   },
                   "type": "PARAGRAPH",
                 },
@@ -13729,6 +15125,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "true",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -13755,6 +15152,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13779,6 +15177,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -13797,6 +15198,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -13811,8 +15213,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -13822,14 +15227,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Same as mother's usual place of residence?",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.address.addressSameAs.label",
+                    "id": "v2.event.birth.action.declare.form.section.father.field.address.addressSameAs.label",
                   },
-                  "optionValues": [
+                  "options": [
                     {
                       "label": {
                         "defaultMessage": "Yes",
                         "description": "Label for form field radio option Yes",
-                        "id": "form.field.label.Yes",
+                        "id": "v2.form.field.label.Yes",
                       },
                       "value": "YES",
                     },
@@ -13837,12 +15242,11 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "No",
                         "description": "Label for form field radio option No",
-                        "id": "form.field.label.No",
+                        "id": "v2.form.field.label.No",
                       },
                       "value": "NO",
                     },
                   ],
-                  "options": {},
                   "required": true,
                   "type": "RADIO_GROUP",
                 },
@@ -13857,6 +15261,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -13883,6 +15288,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13907,6 +15313,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -13925,6 +15334,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -13939,8 +15349,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -13950,7 +15363,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Country",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.country.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.country.label",
                   },
                   "required": true,
                   "type": "COUNTRY",
@@ -13969,6 +15382,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -13985,6 +15401,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -13999,6 +15416,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -14011,6 +15430,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -14037,6 +15457,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14061,6 +15482,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -14079,6 +15503,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -14093,8 +15518,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -14104,7 +15532,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "State",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.state.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.state.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -14123,6 +15551,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -14139,6 +15570,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14153,6 +15585,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -14165,6 +15599,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -14191,6 +15626,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14215,6 +15651,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -14233,6 +15672,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -14247,8 +15687,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -14258,7 +15701,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "District",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.district.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.district.label",
                   },
                   "required": true,
                   "type": "TEXT",
@@ -14277,6 +15720,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -14293,6 +15739,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14307,6 +15754,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -14319,6 +15768,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -14345,6 +15795,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14369,6 +15820,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -14387,6 +15841,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -14401,8 +15856,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -14412,7 +15870,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "City / Town",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.town.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.town.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -14431,6 +15889,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -14447,6 +15908,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14461,6 +15923,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -14473,6 +15937,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -14499,6 +15964,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14523,6 +15989,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -14541,6 +16010,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -14555,8 +16025,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -14566,7 +16039,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 1",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine1.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine1.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -14585,6 +16058,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -14601,6 +16077,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14615,6 +16092,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -14627,6 +16106,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -14653,6 +16133,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14677,6 +16158,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -14695,6 +16179,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -14709,8 +16194,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -14720,7 +16208,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 2",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine2.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine2.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -14739,6 +16227,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -14755,6 +16246,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14769,6 +16261,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -14781,6 +16275,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -14807,6 +16302,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14831,6 +16327,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -14849,6 +16348,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -14863,8 +16363,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -14874,7 +16377,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Address Line 3",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.addressLine3.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.addressLine3.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -14893,6 +16396,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -14909,6 +16415,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "FAR",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14923,6 +16430,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -14935,6 +16444,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -14961,6 +16471,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -14985,6 +16496,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -15003,6 +16517,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -15017,8 +16532,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -15028,7 +16546,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Postcode / Zip",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.other.zipCode.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.other.zipCode.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -15047,6 +16565,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -15065,6 +16586,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15079,6 +16601,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -15091,6 +16615,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -15117,6 +16642,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15141,6 +16667,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -15159,6 +16688,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -15173,8 +16703,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -15184,7 +16717,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Province",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.address.province.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.province.label",
                   },
                   "options": {
                     "type": "ADMIN_STRUCTURE",
@@ -15206,6 +16739,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -15224,6 +16760,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15238,6 +16775,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -15250,6 +16789,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -15276,6 +16816,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15300,6 +16841,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -15318,6 +16862,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -15332,8 +16877,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -15343,7 +16891,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "District",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.address.district.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.district.label",
                   },
                   "options": {
                     "partOf": {
@@ -15368,6 +16916,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -15386,6 +16937,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15400,6 +16952,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -15412,6 +16966,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -15438,6 +16993,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15462,6 +17018,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -15480,6 +17039,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -15494,27 +17054,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
                     },
                   ],
-                  "flexDirection": "row",
                   "hideLabel": true,
                   "id": "father.address.urbanOrRural",
                   "label": {
                     "defaultMessage": "Urban or Rural",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.address.urbanOrRural.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.urbanOrRural.label",
                   },
-                  "optionValues": [
+                  "options": [
                     {
                       "label": {
                         "defaultMessage": "Urban",
                         "description": "Label for form field checkbox option Urban",
-                        "id": "form.field.label.urban",
+                        "id": "v2.form.field.label.urban",
                       },
                       "value": "URBAN",
                     },
@@ -15522,12 +17084,11 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Rural",
                         "description": "Label for form field checkbox option Rural",
-                        "id": "form.field.label.rural",
+                        "id": "v2.form.field.label.rural",
                       },
                       "value": "RURAL",
                     },
                   ],
-                  "options": {},
                   "required": false,
                   "type": "RADIO_GROUP",
                 },
@@ -15545,6 +17106,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -15561,6 +17125,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15575,6 +17140,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -15590,6 +17157,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -15608,6 +17178,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15622,6 +17193,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -15634,6 +17207,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -15660,6 +17234,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15684,6 +17259,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -15702,6 +17280,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -15716,8 +17295,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -15727,7 +17309,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Town",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.town.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.town.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -15746,6 +17328,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -15762,6 +17347,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15776,6 +17362,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -15791,6 +17379,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -15809,6 +17400,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15823,6 +17415,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -15835,6 +17429,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -15861,6 +17456,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15885,6 +17481,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -15903,6 +17502,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -15917,8 +17517,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -15928,7 +17531,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Residential Area",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.residentialArea.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.residentialArea.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -15947,6 +17550,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -15963,6 +17569,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -15977,6 +17584,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -15992,6 +17601,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -16010,6 +17622,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16024,6 +17637,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -16036,6 +17651,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -16062,6 +17678,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16086,6 +17703,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -16104,6 +17724,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -16118,8 +17739,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -16129,7 +17753,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Street",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.street.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.street.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -16148,6 +17772,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -16164,6 +17791,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16178,6 +17806,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -16193,6 +17823,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -16211,6 +17844,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16225,6 +17859,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -16237,6 +17873,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -16263,6 +17900,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16287,6 +17925,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -16305,6 +17946,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -16319,8 +17961,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -16330,7 +17975,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Number",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.number.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.number.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -16349,6 +17994,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -16365,6 +18013,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "RURAL",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16379,6 +18028,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -16394,6 +18045,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -16412,6 +18066,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16426,6 +18081,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -16438,6 +18095,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -16464,6 +18122,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16488,6 +18147,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -16506,6 +18168,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -16520,8 +18183,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -16531,7 +18197,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Postcode / Zip",
                     "description": "This is the label for the field",
-                    "id": "event.action.declare.form.section.person.field.address.zipCode.label",
+                    "id": "v2.event.action.declare.form.section.person.field.address.zipCode.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -16550,6 +18216,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -16568,6 +18237,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "RURAL",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16582,6 +18252,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -16597,6 +18269,9 @@ exports[`birth configuration is parsed 1`] = `
                                   ],
                                   "type": "object",
                                 },
+                                "required": [
+                                  "$form",
+                                ],
                                 "type": "object",
                               },
                             },
@@ -16615,6 +18290,7 @@ exports[`birth configuration is parsed 1`] = `
                                         "FAR",
                                       ],
                                     },
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16629,6 +18305,8 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                         ],
+                        "required": [],
+                        "type": "object",
                       },
                       "type": "HIDE",
                     },
@@ -16641,6 +18319,7 @@ exports[`birth configuration is parsed 1`] = `
                                 "enum": [
                                   "YES",
                                 ],
+                                "type": "string",
                               },
                             },
                             "required": [
@@ -16667,6 +18346,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16691,6 +18371,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -16709,6 +18392,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -16723,8 +18407,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -16734,7 +18421,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Village",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.address.village.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.address.village.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -16752,6 +18439,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16776,6 +18464,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -16794,6 +18485,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -16808,8 +18500,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -16819,7 +18514,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "",
                     "description": "empty string",
-                    "id": "messages.emptyString",
+                    "id": "v2.messages.emptyString",
                   },
                   "type": "DIVIDER",
                 },
@@ -16836,6 +18531,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16860,6 +18556,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -16878,6 +18577,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -16892,8 +18592,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -16903,14 +18606,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Marital Status",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.maritalStatus.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.maritalStatus.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "Single",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusSingle",
+                        "id": "v2.form.field.label.maritalStatusSingle",
                       },
                       "value": "SINGLE",
                     },
@@ -16918,7 +18621,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Married",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusMarried",
+                        "id": "v2.form.field.label.maritalStatusMarried",
                       },
                       "value": "MARRIED",
                     },
@@ -16926,7 +18629,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Widowed",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusWidowed",
+                        "id": "v2.form.field.label.maritalStatusWidowed",
                       },
                       "value": "WIDOWED",
                     },
@@ -16934,7 +18637,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Divorced",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusDivorced",
+                        "id": "v2.form.field.label.maritalStatusDivorced",
                       },
                       "value": "DIVORCED",
                     },
@@ -16942,7 +18645,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Separated",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusSeparated",
+                        "id": "v2.form.field.label.maritalStatusSeparated",
                       },
                       "value": "SEPARATED",
                     },
@@ -16950,7 +18653,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Not stated",
                         "description": "Option for form field: Marital status",
-                        "id": "form.field.label.maritalStatusNotStated",
+                        "id": "v2.form.field.label.maritalStatusNotStated",
                       },
                       "value": "NOT_STATED",
                     },
@@ -16971,6 +18674,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -16995,6 +18699,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -17013,6 +18720,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -17027,8 +18735,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -17038,14 +18749,14 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Level of education",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.educationalAttainment.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.educationalAttainment.label",
                   },
                   "options": [
                     {
                       "label": {
                         "defaultMessage": "No schooling",
                         "description": "Option for form field: no education",
-                        "id": "form.field.label.educationAttainmentNone",
+                        "id": "v2.form.field.label.educationAttainmentNone",
                       },
                       "value": "NO_SCHOOLING",
                     },
@@ -17053,7 +18764,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Primary",
                         "description": "Option for form field: ISCED1 education",
-                        "id": "form.field.label.educationAttainmentISCED1",
+                        "id": "v2.form.field.label.educationAttainmentISCED1",
                       },
                       "value": "PRIMARY_ISCED_1",
                     },
@@ -17061,7 +18772,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Secondary",
                         "description": "Option for form field: ISCED4 education",
-                        "id": "form.field.label.educationAttainmentISCED4",
+                        "id": "v2.form.field.label.educationAttainmentISCED4",
                       },
                       "value": "POST_SECONDARY_ISCED_4",
                     },
@@ -17069,7 +18780,7 @@ exports[`birth configuration is parsed 1`] = `
                       "label": {
                         "defaultMessage": "Tertiary",
                         "description": "Option for form field: ISCED5 education",
-                        "id": "form.field.label.educationAttainmentISCED5",
+                        "id": "v2.form.field.label.educationAttainmentISCED5",
                       },
                       "value": "FIRST_STAGE_TERTIARY_ISCED_5",
                     },
@@ -17090,6 +18801,7 @@ exports[`birth configuration is parsed 1`] = `
                                     "enum": [
                                       "true",
                                     ],
+                                    "type": "string",
                                   },
                                 },
                                 "required": [
@@ -17114,6 +18826,9 @@ exports[`birth configuration is parsed 1`] = `
                                       ],
                                       "type": "object",
                                     },
+                                    "required": [
+                                      "$form",
+                                    ],
                                     "type": "object",
                                   },
                                 },
@@ -17132,6 +18847,7 @@ exports[`birth configuration is parsed 1`] = `
                                             "FATHER",
                                           ],
                                         },
+                                        "type": "string",
                                       },
                                     },
                                     "required": [
@@ -17146,8 +18862,11 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                             ],
+                            "required": [],
+                            "type": "object",
                           },
                         ],
+                        "required": [],
                         "type": "object",
                       },
                       "type": "HIDE",
@@ -17157,7 +18876,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Occupation",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.father.field.occupation.label",
+                    "id": "v2.event.birth.action.declare.form.section.person.field.occupation.label",
                   },
                   "required": false,
                   "type": "TEXT",
@@ -17167,20 +18886,22 @@ exports[`birth configuration is parsed 1`] = `
               "title": {
                 "defaultMessage": "Father's details",
                 "description": "Form section title for fathers details",
-                "id": "form.section.father.title",
+                "id": "v2.form.section.father.title",
               },
             },
             {
               "fields": [
                 {
+                  "configuration": {
+                    "styles": {
+                      "fontVariant": "reg16",
+                    },
+                  },
                   "id": "documents.helper",
                   "label": {
                     "defaultMessage": "The following documents are required",
                     "description": "This is the label for the field",
                     "id": "event.birth.action.declare.form.section.documents.field.helper.label",
-                  },
-                  "options": {
-                    "fontVariant": "reg16",
                   },
                   "type": "PARAGRAPH",
                 },
@@ -17189,7 +18910,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Proof of birth",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.documents.field.proofOfBirth.label",
+                    "id": "v2.event.birth.action.declare.form.section.documents.field.proofOfBirth.label",
                   },
                   "required": false,
                   "type": "FILE",
@@ -17199,7 +18920,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Proof of mother's ID",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.documents.field.proofOfMother.label",
+                    "id": "v2.event.birth.action.declare.form.section.documents.field.proofOfMother.label",
                   },
                   "required": false,
                   "type": "FILE",
@@ -17209,7 +18930,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Proof of father's ID",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.documents.field.proofOfFather.label",
+                    "id": "v2.event.birth.action.declare.form.section.documents.field.proofOfFather.label",
                   },
                   "required": false,
                   "type": "FILE",
@@ -17219,7 +18940,7 @@ exports[`birth configuration is parsed 1`] = `
                   "label": {
                     "defaultMessage": "Other",
                     "description": "This is the label for the field",
-                    "id": "event.birth.action.declare.form.section.documents.field.proofOther.label",
+                    "id": "v2.event.birth.action.declare.form.section.documents.field.proofOther.label",
                   },
                   "required": false,
                   "type": "FILE",
@@ -17229,7 +18950,7 @@ exports[`birth configuration is parsed 1`] = `
               "title": {
                 "defaultMessage": "Upload supporting documents",
                 "description": "Form section title for documents",
-                "id": "form.section.documents.title",
+                "id": "v2.form.section.documents.title",
               },
             },
           ],
@@ -17237,7 +18958,7 @@ exports[`birth configuration is parsed 1`] = `
             "title": {
               "defaultMessage": "Birth declaration for {firstname} {surname}",
               "description": "Title of the form to show in review page",
-              "id": "event.birth.action.declare.form.review.title",
+              "id": "v2.event.birth.action.declare.form.review.title",
             },
           },
           "version": {
@@ -17245,7 +18966,7 @@ exports[`birth configuration is parsed 1`] = `
             "label": {
               "defaultMessage": "Version 1",
               "description": "This is the first version of the form",
-              "id": "event.birth.action.declare.form.version.1",
+              "id": "v2.event.birth.action.declare.form.version.1",
             },
           },
         },
@@ -17253,7 +18974,7 @@ exports[`birth configuration is parsed 1`] = `
       "label": {
         "defaultMessage": "Declare",
         "description": "This is shown as the action name anywhere the user can trigger the action from",
-        "id": "event.birth.action.declare.label",
+        "id": "v2.event.birth.action.declare.label",
       },
       "type": "DECLARE",
     },
@@ -17263,7 +18984,7 @@ exports[`birth configuration is parsed 1`] = `
   "label": {
     "defaultMessage": "Birth declaration",
     "description": "This is what this event is referred as in the system",
-    "id": "event.birth.label",
+    "id": "v2.event.birth.label",
   },
   "summary": {
     "fields": [],
@@ -17272,7 +18993,7 @@ exports[`birth configuration is parsed 1`] = `
       "label": {
         "defaultMessage": "{child.firstname} {child.surname}",
         "description": "This is the title of the summary",
-        "id": "event.birth.summary.title",
+        "id": "v2.event.birth.summary.title",
       },
     },
   },
@@ -17284,7 +19005,7 @@ exports[`birth configuration is parsed 1`] = `
           "label": {
             "defaultMessage": "{child.surname} {child.firstname}",
             "description": "Label for name in all workqueue",
-            "id": "event.birth.workqueue.all.name.label",
+            "id": "v2.event.birth.workqueue.all.name.label",
           },
         },
       ],

--- a/src/form/v2/birth/__snapshots__/birth.test.ts.snap
+++ b/src/form/v2/birth/__snapshots__/birth.test.ts.snap
@@ -5318,7 +5318,16 @@ exports[`birth configuration is parsed 1`] = `
                             "properties": {
                               "informant.dobUnknown": {
                                 "const": "true",
-                                "type": "string",
+                                "oneOf": [
+                                  {
+                                    "const": "true",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "const": "true",
+                                    "type": "boolean",
+                                  },
+                                ],
                               },
                             },
                             "required": [
@@ -8976,7 +8985,16 @@ exports[`birth configuration is parsed 1`] = `
                             "properties": {
                               "mother.dobUnknown": {
                                 "const": "true",
-                                "type": "string",
+                                "oneOf": [
+                                  {
+                                    "const": "true",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "const": "true",
+                                    "type": "boolean",
+                                  },
+                                ],
                               },
                             },
                             "required": [
@@ -13879,7 +13897,16 @@ exports[`birth configuration is parsed 1`] = `
                             "properties": {
                               "father.dobUnknown": {
                                 "const": "true",
-                                "type": "string",
+                                "oneOf": [
+                                  {
+                                    "const": "true",
+                                    "type": "string",
+                                  },
+                                  {
+                                    "const": "true",
+                                    "type": "boolean",
+                                  },
+                                ],
                               },
                             },
                             "required": [

--- a/src/form/v2/birth/forms/child.ts
+++ b/src/form/v2/birth/forms/child.ts
@@ -322,7 +322,7 @@ export const childPage = defineFormPage({
         description: 'This is the label for the field',
         id: 'event.birth.action.declare.form.section.child.field.weightAtBirth.label'
       },
-      options: {
+      configuration: {
         type: 'number',
         postfix: {
           defaultMessage: 'Kilograms (kg)',

--- a/src/form/v2/birth/forms/declare.ts
+++ b/src/form/v2/birth/forms/declare.ts
@@ -271,7 +271,7 @@ export const BIRTH_DECLARE_FORM = defineForm({
             description: 'This is the label for the field',
             id: `event.birth.action.declare.form.section.documents.field.helper.label`
           },
-          options: { fontVariant: 'reg16' }
+          configuration: { styles: { fontVariant: 'reg16' } }
         },
         {
           id: 'documents.proofOfBirth',

--- a/src/form/v2/birth/forms/informant.ts
+++ b/src/form/v2/birth/forms/informant.ts
@@ -160,7 +160,7 @@ export const informantPage = defineFormPage({
         description: 'This is the label for the field',
         id: 'event.birth.action.declare.form.section.informant.field.email.label'
       },
-      options: {
+      configuration: {
         type: 'email'
       }
     }

--- a/src/form/v2/birth/index.ts
+++ b/src/form/v2/birth/index.ts
@@ -54,6 +54,16 @@ export const birthEvent = defineConfig({
   ],
   actions: [
     {
+      type: 'CREATE',
+      label: {
+        defaultMessage: 'Create',
+        description:
+          'This is shown as the action name anywhere the user can trigger the action from',
+        id: 'event.birth.action.create.label'
+      },
+      forms: []
+    },
+    {
       type: 'DECLARE',
       label: {
         defaultMessage: 'Declare',

--- a/src/form/v2/person/address.ts
+++ b/src/form/v2/person/address.ts
@@ -205,10 +205,9 @@ export const getAddressFields = (person: AddressType): FieldConfig[] => {
     },
     {
       id: `${prefix}.urbanOrRural`,
+      // @TODO: Change to SELECT
       type: 'RADIO_GROUP',
-      optionValues: urbanRuralRadioOptions,
-      options: {},
-      flexDirection: 'row',
+      options: urbanRuralRadioOptions,
       required: false,
       label: {
         defaultMessage: 'Urban or Rural',

--- a/src/form/v2/person/index.ts
+++ b/src/form/v2/person/index.ts
@@ -301,7 +301,7 @@ export const getPersonInputCommonFields = (
       description: 'This is the label for the field',
       id: `event.birth.action.declare.form.section.${person}.field.age.label`
     },
-    options: {
+    configuration: {
       postfix: {
         defaultMessage: 'years',
         description: 'This is the postfix for age field',
@@ -341,7 +341,7 @@ export const getPersonInputCommonFields = (
       description: 'This is the label for the field',
       id: `event.birth.action.declare.form.section.${person}.field.addressHelper.label`
     },
-    options: { fontVariant: 'h3' }
+    configuration: { styles: { fontVariant: 'h3' } }
   }
 ]
 
@@ -351,8 +351,7 @@ const fatherAddressFields = [
       {
         id: `${PersonType.father}.addressSameAs`,
         type: 'RADIO_GROUP',
-        optionValues: yesNoRadioOptions,
-        options: {},
+        options: yesNoRadioOptions,
         required: true,
         label: {
           defaultMessage: "Same as mother's usual place of residence?",

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,10 +834,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opencrvs/toolkit@0.0.35-ml":
-  version "0.0.35-ml"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-0.0.35-ml.tgz#cfe9201fc2b203d482241778c2dd93e7e7537c39"
-  integrity sha512-ZgB0OKbKcJd3of5odr+u2qNs99AgItuxFYXYBaD80itL3/1HLG+QvZiUH2uGOseq7cejw1fPsBh2bMEx/S6oZQ==
+"@opencrvs/toolkit@0.0.37-ml":
+  version "0.0.37-ml"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-0.0.37-ml.tgz#b127bf47ca4300f4ceb89c7b80bf0bc72603b6e8"
+  integrity sha512-TUI3feu2pu7dQx8r6PotmM4sNSddAkHlJnOHX7vJmL6pTIoaiBSpdCyLYAgl4dn03OaAjBDzIBesaXJKvw/3FA==
   dependencies:
     "@trpc/client" "^11.0.0-rc.648"
     "@trpc/server" "^11.0.0-rc.532"

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,10 +834,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opencrvs/toolkit@0.0.34-rr":
-  version "0.0.34-rr"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-0.0.34-rr.tgz#4d111eb21e7460034bd813b9c01f177937f16893"
-  integrity sha512-7m8C8Q9RyJBnVCr3UW3ACzb2GsTFtc6cy/Z0u4EaoKwr5VJ3JN5s/KoSwtw6BUdjJdKwfVl4Bvb1+fCTf1/LuQ==
+"@opencrvs/toolkit@0.0.35-ml":
+  version "0.0.35-ml"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-0.0.35-ml.tgz#cfe9201fc2b203d482241778c2dd93e7e7537c39"
+  integrity sha512-ZgB0OKbKcJd3of5odr+u2qNs99AgItuxFYXYBaD80itL3/1HLG+QvZiUH2uGOseq7cejw1fPsBh2bMEx/S6oZQ==
   dependencies:
     "@trpc/client" "^11.0.0-rc.648"
     "@trpc/server" "^11.0.0-rc.532"
@@ -5055,7 +5055,7 @@ string-argv@^0.0.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
   integrity sha512-p6/Mqq0utTQWUeGMi/m0uBtlLZEwXSY3+mXzeRRqw7fz5ezUb28Wr0R99NlfbWaMmL/jCyT9be4jpn7Yz8IO8w==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5080,6 +5080,15 @@ string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^4.1.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -5106,7 +5115,7 @@ stringify-object@^3.2.2:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5126,6 +5135,13 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -5685,7 +5701,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.17.3:
-  version "3.22.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
-  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
+zod@^3.24.1:
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.1.tgz#27445c912738c8ad1e9de1bea0359fa44d9d35ee"
+  integrity sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==


### PR DESCRIPTION
- update toolkit
- update zod (toolkit uses `zod.string().date()` which was not available on the older version