### PR TITLE
fix seed-data job on the deploy workflow

### DIFF
--- a/.github/workflows/clear-environment.yml
+++ b/.github/workflows/clear-environment.yml
@@ -6,6 +6,9 @@ on:
       environment:
         required: true
         type: string
+    outputs:
+      outcome:
+        value: ${{ jobs.reset-data.outputs.outcome }}
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
on the deploy.yml workflow the `seed-data` job never runs, since the output from the `reset` reusable workflow is not accessible to the deploy workflow. 

for the `reset` job, this is not a issue since the previous job is in the same workflow.

https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-outputs-from-a-reusable-workflow

related #159

