### PR TITLE
Chore/unify conditional style

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/toolkit": "0.0.41-ml",
+    "@opencrvs/toolkit": "0.0.42-ml",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",
     "@types/fhir": "^0.0.30",

--- a/src/form/tennis-club-membership.ts
+++ b/src/form/tennis-club-membership.ts
@@ -9,12 +9,11 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { defineConfig, defineForm } from '@opencrvs/toolkit/events'
+import { ActionType, defineConfig, defineForm } from '@opencrvs/toolkit/events'
 import {
-  defineConditional,
+  event,
+  user,
   or,
-  eventHasAction,
-  userHasScope,
   and,
   not,
   field
@@ -273,7 +272,7 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineForm({
               type: 'HIDE',
               conditional: or(
                 field('collector.requesterId').isUndefined(),
-                field('collector.requesterId').not.inArray(['OTHER'])
+                not(field('collector.requesterId').inArray(['OTHER']))
               )
             }
           ],
@@ -344,7 +343,7 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineForm({
               type: 'HIDE',
               conditional: or(
                 field('collector.OTHER.idType').isUndefined(),
-                field('collector.OTHER.idType').not.inArray(['PASSPORT'])
+                not(field('collector.OTHER.idType').inArray(['PASSPORT']))
               )
             }
           ]
@@ -364,7 +363,9 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineForm({
 
               conditional: or(
                 field('collector.OTHER.idType').isUndefined(),
-                field('collector.OTHER.idType').not.inArray(['DRIVING_LICENSE'])
+                not(
+                  field('collector.OTHER.idType').inArray(['DRIVING_LICENSE'])
+                )
               )
             }
           ]
@@ -383,7 +384,7 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineForm({
               type: 'HIDE',
               conditional: or(
                 field('collector.OTHER.idType').isUndefined(),
-                field('collector.OTHER.idType').not.inArray(['REFUGEE_NUMBER'])
+                not(field('collector.OTHER.idType').inArray(['REFUGEE_NUMBER']))
               )
             }
           ]
@@ -402,7 +403,7 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineForm({
               type: 'HIDE',
               conditional: or(
                 field('collector.OTHER.idType').isUndefined(),
-                field('collector.OTHER.idType').not.inArray(['ALIEN_NUMBER'])
+                not(field('collector.OTHER.idType').inArray(['ALIEN_NUMBER']))
               )
             }
           ]
@@ -422,7 +423,7 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineForm({
 
               conditional: or(
                 field('collector.OTHER.idType').isUndefined(),
-                field('collector.OTHER.idType').not.inArray(['OTHER'])
+                not(field('collector.OTHER.idType').inArray(['OTHER']))
               )
             }
           ]
@@ -441,7 +442,7 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineForm({
               type: 'HIDE',
               conditional: or(
                 field('collector.requesterId').isUndefined(),
-                field('collector.requesterId').not.inArray(['OTHER'])
+                not(field('collector.requesterId').inArray(['OTHER']))
               )
             }
           ]
@@ -460,7 +461,7 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineForm({
               type: 'HIDE',
               conditional: or(
                 field('collector.requesterId').isUndefined(),
-                field('collector.requesterId').not.inArray(['OTHER'])
+                not(field('collector.requesterId').inArray(['OTHER']))
               )
             }
           ]
@@ -480,7 +481,7 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineForm({
               type: 'HIDE',
               conditional: or(
                 field('collector.requesterId').isUndefined(),
-                field('collector.requesterId').not.inArray(['OTHER'])
+                not(field('collector.requesterId').inArray(['OTHER']))
               )
             }
           ]
@@ -499,7 +500,7 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineForm({
               type: 'HIDE',
               conditional: or(
                 field('collector.requesterId').isUndefined(),
-                field('collector.requesterId').not.inArray(['OTHER'])
+                not(field('collector.requesterId').inArray(['OTHER']))
               )
             }
           ]
@@ -677,7 +678,7 @@ export const tennisClubMembershipEvent = defineConfig({
   ],
   actions: [
     {
-      type: 'DECLARE',
+      type: ActionType.DECLARE,
       label: {
         defaultMessage: 'Declare',
         description:
@@ -688,12 +689,12 @@ export const tennisClubMembershipEvent = defineConfig({
       conditionals: [
         {
           type: 'SHOW',
-          conditional: defineConditional(not(eventHasAction('DECLARE')))
+          conditional: not(event.hasAction(ActionType.DECLARE))
         }
       ]
     },
     {
-      type: 'DELETE',
+      type: ActionType.DELETE,
       label: {
         defaultMessage: 'Delete draft',
         description:
@@ -704,12 +705,12 @@ export const tennisClubMembershipEvent = defineConfig({
       conditionals: [
         {
           type: 'SHOW',
-          conditional: defineConditional(not(eventHasAction('DECLARE')))
+          conditional: not(event.hasAction(ActionType.DECLARE))
         }
       ]
     },
     {
-      type: 'VALIDATE',
+      type: ActionType.VALIDATE,
       label: {
         defaultMessage: 'Validate',
         description:
@@ -719,15 +720,16 @@ export const tennisClubMembershipEvent = defineConfig({
       conditionals: [
         {
           type: 'SHOW',
-          conditional: defineConditional(
-            and(eventHasAction('DECLARE'), not(eventHasAction('VALIDATE')))
+          conditional: and(
+            event.hasAction(ActionType.DECLARE),
+            not(event.hasAction(ActionType.VALIDATE))
           )
         }
       ],
       forms: [TENNIS_CLUB_FORM]
     },
     {
-      type: 'REGISTER',
+      type: ActionType.REGISTER,
       label: {
         defaultMessage: 'Register',
         description:
@@ -739,10 +741,10 @@ export const tennisClubMembershipEvent = defineConfig({
           type: 'SHOW',
           conditional: and(
             or(
-              eventHasAction('VALIDATE'),
-              and(eventHasAction('DECLARE'), userHasScope('register'))
+              event.hasAction(ActionType.VALIDATE),
+              and(event.hasAction('DECLARE'), user.hasScope('register'))
             ),
-            not(eventHasAction('REGISTER'))
+            not(event.hasAction(ActionType.REGISTER))
           )
         }
       ],
@@ -759,13 +761,13 @@ export const tennisClubMembershipEvent = defineConfig({
       conditionals: [
         {
           type: 'SHOW',
-          conditional: defineConditional(eventHasAction('REGISTER'))
+          conditional: event.hasAction(ActionType.REGISTER)
         }
       ],
       forms: [TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM]
     },
     {
-      type: 'REQUEST_CORRECTION',
+      type: ActionType.REQUEST_CORRECTION,
       label: {
         defaultMessage: 'Request correction',
         description:
@@ -775,7 +777,7 @@ export const tennisClubMembershipEvent = defineConfig({
       conditionals: [
         {
           type: 'SHOW',
-          conditional: defineConditional(and(eventHasAction('REGISTER')))
+          conditional: and(event.hasAction(ActionType.REGISTER))
         }
       ],
       forms: [TENNIS_CLUB_FORM],
@@ -987,11 +989,9 @@ export const tennisClubMembershipEvent = defineConfig({
       conditionals: [
         {
           type: 'SHOW',
-          conditional: defineConditional(
-            or(
-              eventHasAction('VALIDATE'),
-              and(eventHasAction('DECLARE'), userHasScope('register'))
-            )
+          conditional: or(
+            event.hasAction(ActionType.VALIDATE),
+            and(event.hasAction(ActionType.DECLARE), user.hasScope('register'))
           )
         }
       ],

--- a/src/form/v2/birth/__snapshots__/birth.test.ts.snap
+++ b/src/form/v2/birth/__snapshots__/birth.test.ts.snap
@@ -273,26 +273,28 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.dob": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.dob": {
                                       "format": "date",
                                       "formatMaximum": "2025-02-12",
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.dob",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.dob",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -386,27 +388,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "HEALTH_FACILITY",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -458,27 +462,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -582,27 +588,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -706,27 +714,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -830,27 +840,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -954,27 +966,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -1078,27 +1092,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -1202,27 +1218,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -1326,27 +1344,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -1395,27 +1415,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childResidentialAddress.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childResidentialAddress.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childResidentialAddress.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childResidentialAddress.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -1452,27 +1474,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -1524,27 +1548,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childResidentialAddress.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childResidentialAddress.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childResidentialAddress.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childResidentialAddress.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -1581,27 +1607,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -1656,27 +1684,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childResidentialAddress.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childResidentialAddress.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childResidentialAddress.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childResidentialAddress.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -1713,27 +1743,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -1856,27 +1888,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childResidentialAddress.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childResidentialAddress.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childResidentialAddress.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childResidentialAddress.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -1913,27 +1947,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2037,27 +2073,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childResidentialAddress.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childResidentialAddress.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childResidentialAddress.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childResidentialAddress.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2094,27 +2132,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2218,27 +2258,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childResidentialAddress.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childResidentialAddress.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childResidentialAddress.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childResidentialAddress.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2275,27 +2317,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2399,27 +2443,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childResidentialAddress.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childResidentialAddress.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childResidentialAddress.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childResidentialAddress.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2456,27 +2502,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2580,27 +2628,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childResidentialAddress.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childResidentialAddress.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childResidentialAddress.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childResidentialAddress.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2637,27 +2687,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2706,27 +2758,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childResidentialAddress.address.urbanOrRural": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childResidentialAddress.address.urbanOrRural": {
                                       "enum": [
                                         "RURAL",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childResidentialAddress.address.urbanOrRural",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childResidentialAddress.address.urbanOrRural",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2763,27 +2817,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childResidentialAddress.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childResidentialAddress.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childResidentialAddress.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childResidentialAddress.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2820,27 +2876,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "PRIVATE_HOME",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -2889,27 +2947,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -3013,27 +3073,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -3137,27 +3199,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -3261,27 +3325,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -3385,27 +3451,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -3509,27 +3577,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -3633,27 +3703,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -3757,27 +3829,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -3826,27 +3900,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childOther.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childOther.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childOther.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childOther.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -3883,27 +3959,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -3955,27 +4033,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childOther.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childOther.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childOther.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childOther.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -4012,27 +4092,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -4087,27 +4169,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childOther.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childOther.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childOther.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childOther.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -4144,27 +4228,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -4287,27 +4373,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childOther.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childOther.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childOther.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childOther.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -4344,27 +4432,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -4468,27 +4558,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childOther.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childOther.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childOther.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childOther.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -4525,27 +4617,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -4649,27 +4743,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childOther.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childOther.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childOther.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childOther.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -4706,27 +4802,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -4830,27 +4928,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childOther.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childOther.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childOther.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childOther.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -4887,27 +4987,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -5011,27 +5113,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childOther.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childOther.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childOther.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childOther.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -5068,27 +5172,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -5137,27 +5243,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childOther.address.urbanOrRural": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childOther.address.urbanOrRural": {
                                       "enum": [
                                         "RURAL",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childOther.address.urbanOrRural",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childOther.address.urbanOrRural",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -5194,27 +5302,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "childOther.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "childOther.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "childOther.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "childOther.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -5251,27 +5361,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "child.placeOfBirth": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "child.placeOfBirth": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "child.placeOfBirth",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "child.placeOfBirth",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -5553,27 +5665,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.relation": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.relation": {
                                       "enum": [
                                         "OTHER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.relation",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.relation",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -6269,27 +6383,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.idType": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.idType": {
                                       "enum": [
                                         "NATIONAL_ID",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.idType",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.idType",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -6394,27 +6510,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.idType": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.idType": {
                                       "enum": [
                                         "PASSPORT",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.idType",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.idType",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -6519,27 +6637,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.idType": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.idType": {
                                       "enum": [
                                         "BIRTH_REGISTRATION_NUMBER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.idType",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.idType",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -7712,27 +7832,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -7840,27 +7962,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -7971,27 +8095,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -8170,27 +8296,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -8350,27 +8478,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -8530,27 +8660,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -8710,27 +8842,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -8890,27 +9024,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -9015,27 +9151,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.address.urbanOrRural": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.address.urbanOrRural": {
                                       "enum": [
                                         "RURAL",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.address.urbanOrRural",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.address.urbanOrRural",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -9072,27 +9210,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "informant.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "informant.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "informant.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "informant.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -9503,27 +9643,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -9610,27 +9752,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -9749,27 +9893,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -9883,27 +10029,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -10049,27 +10197,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -10160,27 +10310,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -10264,27 +10416,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -10371,27 +10525,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.idType": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.idType": {
                                       "enum": [
                                         "NATIONAL_ID",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.idType",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.idType",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -10459,27 +10615,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -10532,27 +10690,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.idType": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.idType": {
                                       "enum": [
                                         "PASSPORT",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.idType",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.idType",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -10620,27 +10780,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -10693,27 +10855,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.idType": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.idType": {
                                       "enum": [
                                         "BIRTH_REGISTRATION_NUMBER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.idType",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.idType",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -10781,27 +10945,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -10885,27 +11051,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -10988,27 +11156,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -11096,27 +11266,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -11255,27 +11427,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -11414,27 +11588,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -11573,27 +11749,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -11732,27 +11910,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -11891,27 +12071,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -12050,27 +12232,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -12209,27 +12393,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -12282,27 +12468,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -12370,27 +12558,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -12446,27 +12636,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -12534,27 +12726,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -12613,27 +12807,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -12701,27 +12897,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -12848,27 +13046,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -12936,27 +13136,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -13064,27 +13266,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -13152,27 +13356,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -13280,27 +13486,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -13368,27 +13576,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -13496,27 +13706,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -13584,27 +13796,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -13712,27 +13926,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -13800,27 +14016,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -13873,27 +14091,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.address.urbanOrRural": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.address.urbanOrRural": {
                                       "enum": [
                                         "RURAL",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.address.urbanOrRural",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.address.urbanOrRural",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -13930,27 +14150,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "mother.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "mother.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "mother.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "mother.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -14018,27 +14240,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -14122,27 +14346,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -14225,27 +14451,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -14379,27 +14607,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -14517,27 +14747,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -14621,27 +14853,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "MOTHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -14910,27 +15144,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -15017,27 +15253,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -15156,27 +15394,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -15290,27 +15530,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -15456,27 +15698,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -15567,27 +15811,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -15671,27 +15917,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -15778,27 +16026,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.idType": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.idType": {
                                       "enum": [
                                         "NATIONAL_ID",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.idType",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.idType",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -15866,27 +16116,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -15939,27 +16191,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.idType": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.idType": {
                                       "enum": [
                                         "PASSPORT",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.idType",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.idType",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -16027,27 +16281,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -16100,27 +16356,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.idType": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.idType": {
                                       "enum": [
                                         "BIRTH_REGISTRATION_NUMBER",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.idType",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.idType",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -16188,27 +16446,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -16292,27 +16552,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -16395,27 +16657,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -16535,27 +16799,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -16682,27 +16948,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -16866,27 +17134,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -17050,27 +17320,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -17234,27 +17506,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -17418,27 +17692,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -17602,27 +17878,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -17786,27 +18064,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -17970,27 +18250,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -18043,27 +18325,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -18156,27 +18440,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -18232,27 +18518,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -18345,27 +18633,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -18424,27 +18714,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -18537,27 +18829,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -18684,27 +18978,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -18797,27 +19093,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -18925,27 +19223,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -19038,27 +19338,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -19166,27 +19468,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -19279,27 +19583,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -19407,27 +19713,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -19520,27 +19828,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -19648,27 +19958,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -19761,27 +20073,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -19834,27 +20148,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.address.urbanOrRural": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.address.urbanOrRural": {
                                       "enum": [
                                         "RURAL",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.address.urbanOrRural",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.address.urbanOrRural",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -19891,27 +20207,29 @@ exports[`birth configuration is parsed 1`] = `
                             "type": "object",
                           },
                           {
-                            "properties": {
-                              "$form": {
-                                "properties": {
-                                  "father.address.country": {
-                                    "not": {
+                            "not": {
+                              "properties": {
+                                "$form": {
+                                  "properties": {
+                                    "father.address.country": {
                                       "enum": [
                                         "FAR",
                                       ],
+                                      "type": "string",
                                     },
-                                    "type": "string",
                                   },
+                                  "required": [
+                                    "father.address.country",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "father.address.country",
-                                ],
-                                "type": "object",
                               },
+                              "required": [
+                                "$form",
+                              ],
+                              "type": "object",
                             },
-                            "required": [
-                              "$form",
-                            ],
+                            "required": [],
                             "type": "object",
                           },
                         ],
@@ -20004,27 +20322,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -20108,27 +20428,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -20211,27 +20533,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -20365,27 +20689,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],
@@ -20503,27 +20829,29 @@ exports[`birth configuration is parsed 1`] = `
                                 "type": "object",
                               },
                               {
-                                "properties": {
-                                  "$form": {
-                                    "properties": {
-                                      "informant.relation": {
-                                        "not": {
+                                "not": {
+                                  "properties": {
+                                    "$form": {
+                                      "properties": {
+                                        "informant.relation": {
                                           "enum": [
                                             "FATHER",
                                           ],
+                                          "type": "string",
                                         },
-                                        "type": "string",
                                       },
+                                      "required": [
+                                        "informant.relation",
+                                      ],
+                                      "type": "object",
                                     },
-                                    "required": [
-                                      "informant.relation",
-                                    ],
-                                    "type": "object",
                                   },
+                                  "required": [
+                                    "$form",
+                                  ],
+                                  "type": "object",
                                 },
-                                "required": [
-                                  "$form",
-                                ],
+                                "required": [],
                                 "type": "object",
                               },
                             ],

--- a/src/form/v2/birth/forms/child.ts
+++ b/src/form/v2/birth/forms/child.ts
@@ -10,7 +10,7 @@
  */
 
 import { defineFormPage, or, TranslationConfig } from '@opencrvs/toolkit/events'
-import { field } from '@opencrvs/toolkit/conditionals'
+import { field, not } from '@opencrvs/toolkit/conditionals'
 import {
   appendConditionalsToFields,
   createSelectOptions,
@@ -251,7 +251,7 @@ export const childPage = defineFormPage({
           type: 'HIDE',
           conditional: or(
             field('child.dob').isUndefined(),
-            field('child.dob').not.isBefore().now()
+            not(field('child.dob').isBefore().now())
           )
         }
       ]
@@ -290,7 +290,7 @@ export const childPage = defineFormPage({
           type: 'HIDE',
           conditional: or(
             field('child.placeOfBirth').isUndefined(),
-            field('child.placeOfBirth').not.inArray(['HEALTH_FACILITY'])
+            not(field('child.placeOfBirth').inArray(['HEALTH_FACILITY']))
           )
         }
       ]
@@ -302,7 +302,7 @@ export const childPage = defineFormPage({
           type: 'HIDE',
           conditional: or(
             field('child.placeOfBirth').isUndefined(),
-            field('child.placeOfBirth').not.inArray(['PRIVATE_HOME'])
+            not(field('child.placeOfBirth').inArray(['PRIVATE_HOME']))
           )
         }
       ]
@@ -314,7 +314,7 @@ export const childPage = defineFormPage({
           type: 'HIDE',
           conditional: or(
             field('child.placeOfBirth').isUndefined(),
-            field('child.placeOfBirth').not.inArray(['OTHER'])
+            not(field('child.placeOfBirth').inArray(['OTHER']))
           )
         }
       ]

--- a/src/form/v2/birth/forms/declare.ts
+++ b/src/form/v2/birth/forms/declare.ts
@@ -14,7 +14,8 @@ import {
   and,
   defineConditional,
   field,
-  or
+  or,
+  not
 } from '@opencrvs/toolkit/conditionals'
 import { childPage } from './child'
 import { informantPage, InformantTypes } from './informant'
@@ -175,9 +176,9 @@ export const BIRTH_DECLARE_FORM = defineForm({
                 field('mother.detailsNotAvailable').isEqualTo(true),
                 or(
                   field('informant.relation').isUndefined(),
-                  field('informant.relation').not.inArray([
-                    InformantTypes.MOTHER
-                  ])
+                  not(
+                    field('informant.relation').inArray([InformantTypes.MOTHER])
+                  )
                 )
               )
             }
@@ -252,9 +253,9 @@ export const BIRTH_DECLARE_FORM = defineForm({
                 field('father.detailsNotAvailable').isEqualTo(true),
                 or(
                   field('informant.relation').isUndefined(),
-                  field('informant.relation').not.inArray([
-                    InformantTypes.FATHER
-                  ])
+                  not(
+                    field('informant.relation').inArray([InformantTypes.FATHER])
+                  )
                 )
               )
             }

--- a/src/form/v2/birth/forms/informant.ts
+++ b/src/form/v2/birth/forms/informant.ts
@@ -10,7 +10,7 @@
  */
 
 import { defineFormPage, or, TranslationConfig } from '@opencrvs/toolkit/events'
-import { field } from '@opencrvs/toolkit/conditionals'
+import { field, not } from '@opencrvs/toolkit/conditionals'
 import {
   appendConditionalsToFields,
   createSelectOptions,
@@ -111,7 +111,7 @@ export const informantPage = defineFormPage({
           type: 'HIDE',
           conditional: or(
             field('informant.relation').isUndefined(),
-            field('informant.relation').not.inArray([InformantTypes.OTHER])
+            not(field('informant.relation').inArray([InformantTypes.OTHER]))
           )
         }
       ]

--- a/src/form/v2/birth/index.ts
+++ b/src/form/v2/birth/index.ts
@@ -8,12 +8,8 @@
  *
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
-import { defineConfig } from '@opencrvs/toolkit/events'
-import {
-  defineConditional,
-  eventHasAction,
-  not
-} from '@opencrvs/toolkit/conditionals'
+import { ActionType, defineConfig } from '@opencrvs/toolkit/events'
+import { not, event } from '@opencrvs/toolkit/conditionals'
 
 import { BIRTH_DECLARE_FORM } from './forms/declare'
 import { Event } from '@countryconfig/form/types/types'
@@ -54,7 +50,7 @@ export const birthEvent = defineConfig({
   ],
   actions: [
     {
-      type: 'CREATE',
+      type: ActionType.CREATE,
       label: {
         defaultMessage: 'Create',
         description:
@@ -64,7 +60,7 @@ export const birthEvent = defineConfig({
       forms: []
     },
     {
-      type: 'DECLARE',
+      type: ActionType.DECLARE,
       label: {
         defaultMessage: 'Declare',
         description:
@@ -75,7 +71,7 @@ export const birthEvent = defineConfig({
       conditionals: [
         {
           type: 'SHOW',
-          conditional: defineConditional(not(eventHasAction('DECLARE')))
+          conditional: not(event.hasAction(ActionType.DECLARE))
         }
       ]
     }

--- a/src/form/v2/person/address.ts
+++ b/src/form/v2/person/address.ts
@@ -10,7 +10,7 @@
  */
 
 import { FieldConfig, or, TranslationConfig } from '@opencrvs/toolkit/events'
-import { field } from '@opencrvs/toolkit/conditionals'
+import { field, not } from '@opencrvs/toolkit/conditionals'
 import { appendConditionalsToFields, createSelectOptions } from '../utils'
 import { PersonType } from './index'
 
@@ -242,7 +242,7 @@ export const getAddressFields = (person: AddressType): FieldConfig[] => {
           type: 'HIDE',
           conditional: or(
             field(`${prefix}.urbanOrRural`).isUndefined(),
-            field(`${prefix}.urbanOrRural`).not.inArray(['RURAL'])
+            not(field(`${prefix}.urbanOrRural`).inArray(['RURAL']))
           )
         }
       ]
@@ -279,7 +279,7 @@ export const getAddressFields = (person: AddressType): FieldConfig[] => {
           type: 'HIDE',
           conditional: or(
             field(`${person}.address.country`).isUndefined(),
-            field(`${person}.address.country`).not.inArray(['FAR'])
+            not(field(`${person}.address.country`).inArray(['FAR']))
           )
         }
       ]

--- a/src/form/v2/person/index.ts
+++ b/src/form/v2/person/index.ts
@@ -10,7 +10,7 @@
  */
 
 import { FieldConfig, or, TranslationConfig } from '@opencrvs/toolkit/events'
-import { field } from '@opencrvs/toolkit/conditionals'
+import { field, not } from '@opencrvs/toolkit/conditionals'
 import { getAddressFields } from './address'
 import {
   appendConditionalsToFields,
@@ -190,7 +190,7 @@ const getIdFields = (person: PersonType): FieldConfig[] => [
         type: 'HIDE',
         conditional: or(
           field(`${person}.idType`).isUndefined(),
-          field(`${person}.idType`).not.inArray(['NATIONAL_ID'])
+          not(field(`${person}.idType`).inArray(['NATIONAL_ID']))
         )
       }
     ]
@@ -209,7 +209,7 @@ const getIdFields = (person: PersonType): FieldConfig[] => [
         type: 'HIDE',
         conditional: or(
           field(`${person}.idType`).isUndefined(),
-          field(`${person}.idType`).not.inArray(['PASSPORT'])
+          not(field(`${person}.idType`).inArray(['PASSPORT']))
         )
       }
     ]
@@ -228,7 +228,7 @@ const getIdFields = (person: PersonType): FieldConfig[] => [
         type: 'HIDE',
         conditional: or(
           field(`${person}.idType`).isUndefined(),
-          field(`${person}.idType`).not.inArray(['BIRTH_REGISTRATION_NUMBER'])
+          not(field(`${person}.idType`).inArray(['BIRTH_REGISTRATION_NUMBER']))
         )
       }
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,10 +834,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opencrvs/toolkit@0.0.41-ml":
-  version "0.0.41-ml"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-0.0.41-ml.tgz#47f72d312f25adb6e5357a4cfe3e56ce254d8330"
-  integrity sha512-ZicbGI6kAJOXer7Lp7M7eoaKIdkSkj3SjslU9cHsjRjdkzlEa2wIbUqO3jokaj5RY9OCkOiiQUqwT9sC7cIfjw==
+"@opencrvs/toolkit@0.0.42-ml":
+  version "0.0.42-ml"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-0.0.42-ml.tgz#b39d2f1de769d116e150dfbf20960764b758b88c"
+  integrity sha512-1bU9SCNca/ICE1/KfZEwCJYrDaoTxZCGPzzEzvfd71xb6hb3fa9HFILoRxG05Dp5Ow+4XSlHi/iHHoD8/PKsFQ==
   dependencies:
     "@trpc/client" "^11.0.0-rc.648"
     "@trpc/server" "^11.0.0-rc.532"


### PR DESCRIPTION
- use global `not()` over chain method (deprecated)
- use object enum `ActionType` where applicable

Snapshot change is large, since the condition is moved up a level