### PR TITLE
fix: Insecure SSH configuration #7542

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ In order to make the upgrade easier, there are a couple of steps that need to be
 - We make sure that the automatic cleanup job only runs before deployment (instead of cron schedule cleanup).
 - Previously it was possible MongoDB replica set and users were left randomly uninitialised after a deployment. MongoDB initialisation container now retries on failure.
 - On some machines 'file' utility was not preinstalled causing provision to fail. We now install the utility if it doesn't exist.
+- Insecure SSH configuration [#7542](https://github.com/opencrvs/opencrvs-core/issues/7542)
 
 ### Infrastructure breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ In order to make the upgrade easier, there are a couple of steps that need to be
 - We make sure that the automatic cleanup job only runs before deployment (instead of cron schedule cleanup).
 - Previously it was possible MongoDB replica set and users were left randomly uninitialised after a deployment. MongoDB initialisation container now retries on failure.
 - On some machines 'file' utility was not preinstalled causing provision to fail. We now install the utility if it doesn't exist.
-- Insecure SSH configuration [#7542](https://github.com/opencrvs/opencrvs-core/issues/7542)
+- Restrict supported key exchange, cipher and MAC algorithms for SSH configuration [#7542](https://github.com/opencrvs/opencrvs-core/issues/7542)
 
 ### Infrastructure breaking changes
 

--- a/infrastructure/server-setup/files/sshd_audit_hardening.22.04.conf
+++ b/infrastructure/server-setup/files/sshd_audit_hardening.22.04.conf
@@ -1,0 +1,10 @@
+# Source: https://www.ssh-audit.com/hardening_guides.html#ubuntu_24_04_lts
+# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com hardening guide.
+KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,gss-curve25519-sha256-,diffie-hellman-group16-sha512,gss-group16-sha512-,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-gcm@openssh.com,aes128-ctr
+MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
+HostKeyAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512,rsa-sha2-256
+CASignatureAlgorithms sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512,rsa-sha2-256
+GSSAPIKexAlgorithms gss-curve25519-sha256-,gss-group16-sha512-
+HostbasedAcceptedAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-256
+PubkeyAcceptedAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-256

--- a/infrastructure/server-setup/files/sshd_audit_hardening.24.04.conf
+++ b/infrastructure/server-setup/files/sshd_audit_hardening.24.04.conf
@@ -1,0 +1,11 @@
+# Source: https://www.ssh-audit.com/hardening_guides.html#ubuntu_24_04_lts
+# Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com hardening guide.
+KexAlgorithms sntrup761x25519-sha512@openssh.com,gss-curve25519-sha256-,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256,gss-group16-sha512-,diffie-hellman-group16-sha512
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-gcm@openssh.com,aes128-ctr
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
+RequiredRSASize 3072
+HostKeyAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512,rsa-sha2-256
+CASignatureAlgorithms sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512,rsa-sha2-256
+GSSAPIKexAlgorithms gss-curve25519-sha256-,gss-group16-sha512-
+HostbasedAcceptedAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512,rsa-sha2-256
+PubkeyAcceptedAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512,rsa-sha2-256

--- a/infrastructure/server-setup/tasks/users.yml
+++ b/infrastructure/server-setup/tasks/users.yml
@@ -87,6 +87,46 @@
     line: '#@include common-auth'
     state: present
 
+- name: Check short Diffie-Hellman keys
+  ansible.builtin.shell: |
+    awk '$5 < 3071' /etc/ssh/moduli | grep -q .
+  register: short_dh_keys
+  ignore_errors: yes
+
+- name: Remove short Diffie-Hellman keys
+  ansible.builtin.shell: |
+    awk '$5 >= 3071' /etc/ssh/moduli > /etc/ssh/moduli.safe
+    mv /etc/ssh/moduli.safe /etc/ssh/moduli
+  when: short_dh_keys.rc == 0
+  become: yes
+
+# Cleanup weak server keys 
+- name: Remove existing SSH host keys except for RSA and ED25519
+  ansible.builtin.command:
+    cmd: "find /etc/ssh -type f -name 'ssh_host_*' ! -name 'ssh_host_rsa_key' ! -name 'ssh_host_ed25519_key' -exec rm -f {} +"
+- name: Generate new RSA SSH host key if it does not exist
+  ansible.builtin.command:
+    cmd: "ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key -N ''"
+  args:
+    creates: /etc/ssh/ssh_host_rsa_key
+
+- name: Generate new ED25519 SSH host key if it does not exist
+  ansible.builtin.command:
+    cmd: "ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ''"
+  args:
+    creates: /etc/ssh/ssh_host_ed25519_key
+
+# Allow only Strong server keys
+- name: Ensure HostKey for ED25519 is present in sshd_config
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    line: "HostKey /etc/ssh/ssh_host_ed25519_key"
+
+- name: Ensure HostKey for RSA is present in sshd_config
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    line: "HostKey /etc/ssh/ssh_host_rsa_key"
+
 - name: Set AuthenticationMethods to publickey,keyboard-interactive
   lineinfile:
     path: /etc/ssh/sshd_config
@@ -146,23 +186,52 @@
 - name: Only require public key from the user "{{ ansible_user }}"
   blockinfile:
     path: /etc/ssh/sshd_config
+    # Match block must have ending Match all
+    # https://linux.die.net/man/5/sshd_config
     block: |
       Match User {{ ansible_user }}
         PasswordAuthentication no
         AuthenticationMethods publickey
+      Match all
     marker: '# {mark} ANSIBLE MANAGED BLOCK FOR USER {{ ansible_user }}'
   become: yes
+
+
+# Add restriction configuration to sshd_config
+# For Ubuntu 22.04
+- name: SSHD Restrict key exchange, cipher, and MAC algorithms (Ubuntu 22.04)
+  ansible.builtin.copy:
+    src: ./files/sshd_audit_hardening.22.04.conf
+    dest: /etc/ssh/sshd_config.d/audit_hardening.conf
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] == 'Ubuntu'
+    - ansible_facts['distribution_version'] is version('22.04', '<=')
+# For Ubuntu 24.04
+- name: SSHD Restrict key exchange, cipher, and MAC algorithms (Ubuntu 24.04)
+  ansible.builtin.copy:
+    src: ./files/sshd_audit_hardening.24.04.conf
+    dest: /etc/ssh/sshd_config.d/ssh-audit_hardening.conf
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] == 'Ubuntu'
+    - ansible_facts['distribution_version'] == '24.04'
+
+- name: Check SSH config syntax
+  command: sshd -T
+  register: check_result
 
 - name: Enable logging in to the provisioning user with specified SSH keys
   authorized_key:
     user: '{{ ansible_user }}'
     key: '{{ item }}'
   with_items: '{{ additional_keys_for_provisioning_user | default([]) }}'
-
-- name: Check SSH config syntax
-  command: sshd -T
-  register: check_result
-  ignore_errors: yes
 
 # Ubuntu 22.10
 - name: Check if sshd service exists


### PR DESCRIPTION
This PR aims to fix issue described at https://github.com/opencrvs/opencrvs-core/issues/7542 by using scripted documentation from https://www.ssh-audit.com/hardening_guides.html#ubuntu_24_04_lts

# Whats new?
- Added files folder to keep files for upload by ansible

# Test results:
- Test results when /etc/ssh/moduli doesn't have short DH keys:
  - Ubuntu 22.04: https://github.com/adskyiproger/opencrvs-countryconfig/actions/runs/13326572681/job/37221022719
  - Ubuntu 24.04: https://github.com/adskyiproger/opencrvs-countryconfig/actions/runs/13327065548/job/37222596865
- Test results when /etc/ssh/moduli has short DH keys:
  - Ubuntu 22.04: https://github.com/adskyiproger/opencrvs-countryconfig/actions/runs/13326711225/job/37221458269
  - Ubuntu 24.04: https://github.com/adskyiproger/opencrvs-countryconfig/actions/runs/13328344164/job/37226525928
