### PR TITLE
fix: Remove manual approval for staging and production deployment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -25,14 +25,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: trstringer/manual-approval@v1
-        with:
-          secret: ${{ github.TOKEN }}
-          approvers: euanmillar,rikukissa
-          minimum-approvals: 1
-          issue-title: 'Deploy (${{ github.event.inputs.environment }}): core: ${{ github.event.inputs.core-image-tag }} country config: ${{ github.event.inputs.countryconfig-image-tag }}'
-          issue-body: 'Please approve or deny the deployment of core: ${{ github.event.inputs.core-image-tag }} country config: ${{ github.event.inputs.countryconfig-image-tag }} to ${{ github.event.inputs.environment }}'
-          exclude-workflow-initiator-as-approver: false
       - name: Clone core
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Manual approval process is the flow that should be implemented for us in opencrvs-farajaland fork or configuration for particular country, but not for repository exposed as part of the product.

E/g Someone makes a fork from opencrvs countryconfig and faces an issue with github action waiting for approval from our core team, like here: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/13457268501/job/37603920565