### PR TITLE
fix: Add the isAgeInYearsBetween validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ In order to make the upgrade easier, there are a couple of steps that need to be
 - **User scopes** Introduce granular scopes to grant specific permissions to a particular role. The specifics about the introduced scopes can be found here: _Link to scopes description file_
 - **Refactored certificate handling:** SVGs are no longer stored in the database; streamlined configurations now include certificate details, and clients request SVGs directly via URLs.
 - Add constant.humanName to allow countries to have custom ordering on their full name e.g. start with `lastName` or `firstName` [#6830](https://github.com/opencrvs/opencrvs-core/issues/6830)
-- Add `isAgeInYearsBetween` validator to enable validation that will constraint a date to be only valid if it falls within a specified date range [#7636](https://github.com/opencrvs/opencrvs-core/issues/7636)
+- Add `isAgeInYearsBetween` validator to enable validation that will constraint a date to be only valid if it falls within a specified date range. The `isInformantOfLegalAge` validator is now deprecated and removed in favor of `isAgeInYearsBetween` validator [#7636](https://github.com/opencrvs/opencrvs-core/issues/7636)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ In order to make the upgrade easier, there are a couple of steps that need to be
 
   The `roles.ts` file now defines all the roles available in the system. New roles can be added & existing roles can be customized by giving them different scopes.
 
-  _N.B. The default roles generated in the `roles.ts` file during migration should not be removed to maintain backwards compatibility_
-
+ *N.B. The default roles generated in the `roles.ts` file during migration should not be removed to maintain backwards compatibility*
 ### Breaking changes
 
 - `INFORMANT_SIGNATURE` & `INFORMANT_SIGNATURE_REQUIRED` are now deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,16 @@
 ## 1.7.0 Release candidate
 
 ### Migration notes
-
 In order to make the upgrade easier, there are a couple of steps that need to be performed which will make the codebase ready for the upgrade:
-
-- Run this command from the root of the countryconfig repository `curl https://raw.githubusercontent.com/opencrvs/opencrvs-countryconfig/configurable-roles/src/upgrade-to-1_7.ts | npx ts-node -T --cwd ./src`
+- Run this command from the root of the countryconfig repository ```curl https://raw.githubusercontent.com/opencrvs/opencrvs-countryconfig/configurable-roles/src/upgrade-to-1_7.ts | npx ts-node -T --cwd ./src```
 
   It will remove `roles.csv` and generate a `roles.ts` file. It will also update the corresponding role column in `default-employees.csv` & `prod-employees.csv` while adding the corresponding translations in `client.csv`. The employee files are only used when seeding new environments, if you already have a v1.6.x of OpenCRVS deployed, the data in the environment will automatically get migrated after deploying the upgrade. The changes in these two files are made to keep the roles in sync with your previously deployed environments, if any.
-
 - After pulling in the v1.7.0 changes reject the changes incoming to `roles.ts`, `default-employees.csv` & `prod-employees.csv` files as we used the script above to auto-generate them.
 
   The `roles.ts` file now defines all the roles available in the system. New roles can be added & existing roles can be customized by giving them different scopes.
 
- *N.B. The default roles generated in the `roles.ts` file during migration should not be removed to maintain backwards compatibility*
+  *N.B. The default roles generated in the `roles.ts` file during migration should not be removed to maintain backwards compatibility*
+
 ### Breaking changes
 
 - `INFORMANT_SIGNATURE` & `INFORMANT_SIGNATURE_REQUIRED` are now deprecated
@@ -24,7 +22,7 @@ In order to make the upgrade easier, there are a couple of steps that need to be
 ### New features
 
 - Update the translations for System user add/edit form, `Last name` to `User's surname` and `First name` to `User's first name` to make them less confusing for system users [#6830](https://github.com/opencrvs/opencrvs-core/issues/6830)
-- **User scopes** Introduce granular scopes to grant specific permissions to a particular role. The specifics about the introduced scopes can be found here: _Link to scopes description file_
+- **User scopes** Introduce granular scopes to grant specific permissions to a particular role. The specifics about the introduced scopes can be found here: *Link to scopes description file*
 - **Refactored certificate handling:** SVGs are no longer stored in the database; streamlined configurations now include certificate details, and clients request SVGs directly via URLs.
 - Add constant.humanName to allow countries to have custom ordering on their full name e.g. start with `lastName` or `firstName` [#6830](https://github.com/opencrvs/opencrvs-core/issues/6830)
 - Add `isAgeInYearsBetween` validator to enable validation that will constraint a date to be only valid if it falls within a specified date range. The `isInformantOfLegalAge` validator is now deprecated and removed in favor of `isAgeInYearsBetween` validator [#7636](https://github.com/opencrvs/opencrvs-core/issues/7636)
@@ -54,7 +52,6 @@ In order to make the upgrade easier, there are a couple of steps that need to be
 ```
 INSERT CSV ROWS IN ENGLISH ONLY
 ```
-
 ## 1.6.1 Release candidate
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,18 @@
 ## 1.7.0 Release candidate
 
 ### Migration notes
+
 In order to make the upgrade easier, there are a couple of steps that need to be performed which will make the codebase ready for the upgrade:
-- Run this command from the root of the countryconfig repository ```curl https://raw.githubusercontent.com/opencrvs/opencrvs-countryconfig/configurable-roles/src/upgrade-to-1_7.ts | npx ts-node -T --cwd ./src```
+
+- Run this command from the root of the countryconfig repository `curl https://raw.githubusercontent.com/opencrvs/opencrvs-countryconfig/configurable-roles/src/upgrade-to-1_7.ts | npx ts-node -T --cwd ./src`
 
   It will remove `roles.csv` and generate a `roles.ts` file. It will also update the corresponding role column in `default-employees.csv` & `prod-employees.csv` while adding the corresponding translations in `client.csv`. The employee files are only used when seeding new environments, if you already have a v1.6.x of OpenCRVS deployed, the data in the environment will automatically get migrated after deploying the upgrade. The changes in these two files are made to keep the roles in sync with your previously deployed environments, if any.
+
 - After pulling in the v1.7.0 changes reject the changes incoming to `roles.ts`, `default-employees.csv` & `prod-employees.csv` files as we used the script above to auto-generate them.
 
   The `roles.ts` file now defines all the roles available in the system. New roles can be added & existing roles can be customized by giving them different scopes.
 
-  *N.B. The default roles generated in the `roles.ts` file during migration should not be removed to maintain backwards compatibility*
+  _N.B. The default roles generated in the `roles.ts` file during migration should not be removed to maintain backwards compatibility_
 
 ### Breaking changes
 
@@ -22,9 +25,10 @@ In order to make the upgrade easier, there are a couple of steps that need to be
 ### New features
 
 - Update the translations for System user add/edit form, `Last name` to `User's surname` and `First name` to `User's first name` to make them less confusing for system users [#6830](https://github.com/opencrvs/opencrvs-core/issues/6830)
-- **User scopes** Introduce granular scopes to grant specific permissions to a particular role. The specifics about the introduced scopes can be found here: *Link to scopes description file*
+- **User scopes** Introduce granular scopes to grant specific permissions to a particular role. The specifics about the introduced scopes can be found here: _Link to scopes description file_
 - **Refactored certificate handling:** SVGs are no longer stored in the database; streamlined configurations now include certificate details, and clients request SVGs directly via URLs.
 - Add constant.humanName to allow countries to have custom ordering on their full name e.g. start with `lastName` or `firstName` [#6830](https://github.com/opencrvs/opencrvs-core/issues/6830)
+- Add `isAgeInYearsBetween` validator to enable validation that will constraint a date to be only valid if it falls within a specified date range [#7636](https://github.com/opencrvs/opencrvs-core/issues/7636)
 
 ### Improvements
 
@@ -51,6 +55,7 @@ In order to make the upgrade easier, there are a couple of steps that need to be
 ```
 INSERT CSV ROWS IN ENGLISH ONLY
 ```
+
 ## 1.6.1 Release candidate
 
 ### Bug fixes

--- a/src/form/birth/index.ts
+++ b/src/form/birth/index.ts
@@ -247,6 +247,10 @@ export const birthForm: ISerializedForm = {
                 {
                   operation: 'dateInPast',
                   parameters: []
+                },
+                {
+                  operation: 'isAgeInYearsBetween',
+                  parameters: [16, 150]
                 }
               ],
               certificateHandlebars.informantBirthDate

--- a/src/form/birth/index.ts
+++ b/src/form/birth/index.ts
@@ -250,7 +250,7 @@ export const birthForm: ISerializedForm = {
                 },
                 {
                   operation: 'isAgeInYearsBetween',
-                  parameters: [16, 150]
+                  parameters: [16, 100]
                 }
               ],
               certificateHandlebars.informantBirthDate

--- a/src/form/death/index.ts
+++ b/src/form/death/index.ts
@@ -280,7 +280,7 @@ export const deathForm = {
                 },
                 {
                   operation: 'isAgeInYearsBetween',
-                  parameters: [16, 150]
+                  parameters: [16, 100]
                 }
               ],
               certificateHandlebars.informantBirthDate

--- a/src/form/death/index.ts
+++ b/src/form/death/index.ts
@@ -277,6 +277,10 @@ export const deathForm = {
                 {
                   operation: 'dateInPast',
                   parameters: []
+                },
+                {
+                  operation: 'isAgeInYearsBetween',
+                  parameters: [16, 150]
                 }
               ],
               certificateHandlebars.informantBirthDate

--- a/src/form/marriage/index.ts
+++ b/src/form/marriage/index.ts
@@ -125,6 +125,10 @@ export const marriageForm: ISerializedForm = {
                 {
                   operation: 'dateInPast',
                   parameters: []
+                },
+                {
+                  operation: 'isAgeInYearsBetween',
+                  parameters: [16, 150]
                 }
               ],
               certificateHandlebars.informantBirthDate

--- a/src/form/marriage/index.ts
+++ b/src/form/marriage/index.ts
@@ -128,7 +128,7 @@ export const marriageForm: ISerializedForm = {
                 },
                 {
                   operation: 'isAgeInYearsBetween',
-                  parameters: [16, 150]
+                  parameters: [16, 100]
                 }
               ],
               certificateHandlebars.informantBirthDate

--- a/src/form/types/validators.ts
+++ b/src/form/types/validators.ts
@@ -47,6 +47,9 @@ type CoreValidator =
   | 'duplicateIDNumber'
   | 'isValidDeathOccurrenceDate'
   | 'isMoVisitDateAfterBirthDateAndBeforeDeathDate'
+  /**
+   * @deprecated This validator is deprecated and will be removed in future releases. Use `isAgeInYearsBetween` instead
+   */
   | 'isInformantOfLegalAge'
   | 'greaterThanZero'
   | 'notGreaterThan'

--- a/src/form/types/validators.ts
+++ b/src/form/types/validators.ts
@@ -51,6 +51,7 @@ type CoreValidator =
    * @deprecated This validator is deprecated and will be removed in future releases. Use `isAgeInYearsBetween` instead
    */
   | 'isInformantOfLegalAge'
+  | 'isAgeInYearsBetween'
   | 'greaterThanZero'
   | 'notGreaterThan'
 

--- a/src/form/types/validators.ts
+++ b/src/form/types/validators.ts
@@ -47,10 +47,6 @@ type CoreValidator =
   | 'duplicateIDNumber'
   | 'isValidDeathOccurrenceDate'
   | 'isMoVisitDateAfterBirthDateAndBeforeDeathDate'
-  /**
-   * @deprecated This validator is deprecated and will be removed in future releases. Use `isAgeInYearsBetween` instead
-   */
-  | 'isInformantOfLegalAge'
   | 'isAgeInYearsBetween'
   | 'greaterThanZero'
   | 'notGreaterThan'

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -2320,6 +2320,7 @@ validations.facilityMustBeSelected,The error message appears when no valid facil
 validations.greaterThanZero,The error message appears when input is less than or equal to 0,Must be a greater than zero,Doit être supérieur à zéro
 validations.illegalMarriageAge,The error message appears when the birth date is not old enough to register for marriage,Illegal age of marriage,Age illègale pour mariage
 validations.invalidDate,The error message that appears when a date field is invalid,Invalid date field,Champ de date invalide
+validations.isAgeInYearsBetween,The error message that appears when age for the given date is outside the legal age range,Age must be between {min} and {max} years,L'âge doit être compris entre {min} et {max} ans.
 validations.isDateNotAfterDeath,The error message appears when the given date of death is not valid,Date of birth must be before date of death,La date doit être antérieure à la date de décès
 validations.isDateNotBeforeBirth,The error message appears when the given date of death is not valid,Date of death must be after deceased date of birth,La date doit être postérieure à la date de naissance du défunt
 validations.isInformantOfLegalAge,The error message appears when the informant is not old enough to register an event,Informant is not of legal age,L'informateur n'est pas majeur


### PR DESCRIPTION
Add the isAgeInYearsBetween and deprecate the isInformantOfLegalAge validator To warn countries still using it that it will not be supported in future releases

linked Core PR: https://github.com/opencrvs/opencrvs-core/pull/8430

https://github.com/opencrvs/opencrvs-core/issues/7636