### PR TITLE
feat: Auto sync changes to Farajaland from countryconfig (#8716)

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -1,0 +1,117 @@
+# name: Sync Changes to Farajaland
+#
+# This GitHub Actions workflow automatically synchronizes changes from an
+# OpenCRVS Countryconfig repository to a forked Farajaland repository whenever
+# a pull request is merged. The workflow performs the following steps:
+# 
+# 1. Checkout the base branch of the pull request from the OpenCRVS Countryconfig repository.
+# 2. Check if the pull request base branch exists in the Farajaland repository.
+# 3. If the branch exists, attempt to sync the Farajaland fork with the latest changes.
+# 4. If syncing fails due to conflicts, create a pull request in the Farajaland repository to manually merge the changes.
+# 5. Send a Slack notification with the status of the sync operation.
+#
+# Trigger:
+# - This workflow is triggered by a `pull_request` event with the `closed` type, specifically when a pull request is merged.
+#
+# Job:
+# - sync_farajaland: Executes the steps to sync changes and send notifications. Only runs if the pull request is merged.
+#
+# Action secrets:
+# - `FORK_ORGANISATION_TOKEN`: A personal access token with access to the Farajaland repository.
+# - `FORK_REPOSITORY_ORGANISATION`: The organisation name of the Farajaland repository.
+# - `FORK_REPOSITORY_NAME`: The name of the Farajaland repository.
+# - `SLACK_BOT_TOKEN`: A Slack bot token for sending notifications.
+
+name: Sync Changes to Farajaland
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  sync_farajaland:
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    env:
+      BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FORK_REPOSITORY_PATH: "${{ secrets.FORK_REPOSITORY_ORGANISATION }}/${{ secrets.FORK_REPOSITORY_NAME }}"
+    steps:
+      - name: Checkout OpenCRVS Countryconfig repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Check if PR branch exists in Farajaland repository
+        id: check_branch
+        run: |
+          if git ls-remote --heads https://${GH_TOKEN}@github.com/${FORK_REPOSITORY_PATH}.git "$BASE_BRANCH" | grep "$BASE_BRANCH"; then
+            echo "branch_exists=true" >> $GITHUB_ENV
+          else
+            echo "=============================================="
+            echo " 🚀 Branch $BASE_BRANCH doesn't exist in repository ${FORK_REPOSITORY_PATH}"
+            echo " 🚪 Doing exit"
+            echo "=============================================="
+            echo "branch_exists=false" >> $GITHUB_ENV
+          fi
+
+      - name: Sync Farajaland Fork repository
+        id: sync_fork
+        if: env.branch_exists == 'true'
+        continue-on-error: true
+        run: |
+          gh repo sync ${FORK_REPOSITORY_PATH} --branch ${BASE_BRANCH}
+          echo STATUS="Synced" >> $GITHUB_ENV
+
+      - name: Create PR in ${{ secrets.FORK_REPOSITORY_ORGANISATION }}/${{ secrets.FORK_REPOSITORY_NAME }}
+        if: steps.sync_fork.outcome == 'failure'
+        run: |
+          echo "The 'sync_fork' step failed. Creating a PR in ${SYNC_FORK_REPOSITORY_PATH}"
+          if gh pr create \
+            --repo ${FORK_REPOSITORY_PATH} \
+            --base ${BASE_BRANCH} \
+            --head opencrvs:${BASE_BRANCH} \
+            --title "Update Farajaland from ${BASE_BRANCH}" \
+            --body \
+          """
+          This PR updates the ${BASE_BRANCH} branch with the latest changes from
+          the original repository https://github.com/${{ github.repository }}.
+          """ 1>result.txt 2>&1; then
+              printf "PR created successfully: $(grep ${FORK_REPOSITORY_PATH} result.txt)\n"
+              echo RESULT=$(grep ${FORK_REPOSITORY_PATH} result.txt) >> $GITHUB_ENV
+              echo STATUS="Created" >> $GITHUB_ENV
+          else
+              if grep -q "already exists" result.txt; then
+                  printf "PR already exists in Farajaland repo: $(grep ${FORK_REPOSITORY_PATH} result.txt)\n"
+                  echo RESULT=$(grep ${FORK_REPOSITORY_PATH} result.txt) >> $GITHUB_ENV
+                  echo STATUS="Created" >> $GITHUB_ENV
+              else
+                  echo "Failed to create PR: $(cat result.txt)"
+                  echo RESULT=$(cat result.txt) >> $GITHUB_ENV
+                  echo STATUS="Failed" >> $GITHUB_ENV
+              fi
+          fi
+      - name: Send slack notification
+        run: |
+          [ "x$STATUS" == "xSynced" ] && \
+              FORK_STATUS="✅ Changes synced with Farajaland repo https://github.com/${FORK_REPOSITORY_PATH}"
+          [ "x$STATUS" == "xCreated" ] && \
+              FORK_STATUS="⚠️ Changes was not synced with Farajaland repo due to merge conflicts, please merge PR $RESULT manually to keep Farajaland in sync Countryconfig"
+          [ "x$STATUS" == "xFailed" ] && \
+              FORK_STATUS="❌ Failed to create PR in Farajaland repository: $RESULT"
+          BODY="""
+          Pull request https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+          authored by ${{ github.actor }} from branch ${{ github.head_ref }} was merged into ${BASE_BRANCH}.
+
+          $FORK_STATUS
+          """
+          echo "$BODY"
+
+          curl -X POST https://slack.com/api/chat.postMessage \
+          -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+          -H 'Content-type: application/json' \
+          --data "{
+            'channel': 'C02LU432JGK',
+            'text': '$BODY'
+          }"


### PR DESCRIPTION
# Test results

1. Sync to Farajaland without conflicts: https://github.com/opencrvs/poc-core-test/actions/runs/13568515297, slack message: 
    <img width="445" alt="image" src="https://github.com/user-attachments/assets/e55f539e-d76b-49e8-a65e-14034e8af8b2" />
2. Sync to Farajaland failed due to conflict and PR doesn't exist: https://github.com/opencrvs/poc-core-test/actions/runs/13569504713/job/37930609422, slack message:
    <img width="494" alt="image" src="https://github.com/user-attachments/assets/fd5d666a-438b-4e2c-9a2e-4817bd0f2582" />
3. Sync to Farajaland failed due to conflict and PR exists: https://github.com/opencrvs/poc-core-test/actions/runs/13568453465/job/37927002873, Slack message: 
    <img width="453" alt="image" src="https://github.com/user-attachments/assets/96043c35-99e3-468f-943c-1a6680e304fe" />
4. Case with failure was not fully tested, but should work properly as well.


All slack messages can be found here: https://opencrvsworkspace.slack.com/archives/C02LU432JGK/p1740665493604159

**NOTE:** THIS CODE was test on dedicated repositories, probably followup PR or creating dedicated secret for `gh` will be required:

- https://github.com/adskyiproger/poc-core-test-my/tree/main
- https://github.com/opencrvs/poc-core-test


# Pitfalls

Existing solution https://github.com/peter-evans/create-pull-request/tree/main allows you to create PR but with less options to control, e/g: PR creation may fail, but you will not know exact failure reason. If PR already exists you will not be able to get PR number without debugging using shell script. Having third-party actions my result in not expected behavior, in this case it's more clear to go with bash script.