### PR TITLE
fix: set shimataro action `if_key_exists` to replace to avoid id_rsa conflit

### DIFF
--- a/.github/workflows/clear-environment.yml
+++ b/.github/workflows/clear-environment.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ env.KNOWN_HOSTS }}
+          if_key_exists: replace
 
       - name: Reset data
         id: reset-data

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ env.KNOWN_HOSTS }}
+          if_key_exists: replace
 
       - name: Unset KNOWN_HOSTS variable
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ env.KNOWN_HOSTS }}
+          if_key_exists: replace
 
       - name: Unset KNOWN_HOSTS variable
         run: |

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ env.KNOWN_HOSTS }}
+          if_key_exists: replace
 
       - name: Write backup SSH key to file
         if: needs.get-backup-ssh-key.outputs.environment_exists == 'true'

--- a/.github/workflows/reset-2fa.yml
+++ b/.github/workflows/reset-2fa.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ env.KNOWN_HOSTS }}
+          if_key_exists: replace
 
       - name: Remove 2FA
         run: |


### PR DESCRIPTION
### Description

This PR fixes the conflict with the `id_rsa` file in GitHub Actions by setting the `if_key_exists` option of the `shimataro/ssh-key-action` to `replace`.

### Changes

- Updated the `shimataro/ssh-key-action` configuration to use `if_key_exists: replace`.

### Issue

This resolves the conflict with the `id_rsa` file during GitHub Actions execution.

Related to this https://github.com/opencrvs/opencrvs-core/pull/8816