### PR TITLE
fix: Create PR in Farajaland repository

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -22,7 +22,7 @@
 # - `SLACK_BOT_TOKEN`: A Slack bot token for sending notifications.
 
 name: Sync Changes to Farajaland
-
+# Test sync
 on:
   pull_request:
     types:
@@ -30,13 +30,14 @@ on:
 
 jobs:
   sync_farajaland:
-    if: ${{ github.event.pull_request.merged == true }}
+    if: ${{ github.event.pull_request.merged == true }} && ${{github.event.pull_request.base.repo.full_name == 'opencrvs/opencrvs-countryconfig' }}
     runs-on: ubuntu-latest
     env:
       BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+      UPSTREAM_REPOSITORY: ${{ github.repository }}
       # Check token under Olli's account
       GH_TOKEN: ${{ secrets.FORK_ORGANISATION_TOKEN }}
-      FORK_REPOSITORY_PATH: "${{ secrets.FORK_REPOSITORY_ORGANISATION }}/${{ secrets.FORK_REPOSITORY_NAME }}"
+      FORK_REPOSITORY_PATH: "${{ vars.FORK_REPOSITORY_ORGANISATION }}/${{ vars.FORK_REPOSITORY_NAME }}"
     steps:
       - name: Checkout OpenCRVS Countryconfig repository
         uses: actions/checkout@v4
@@ -64,20 +65,56 @@ jobs:
           gh repo sync ${FORK_REPOSITORY_PATH} --branch ${BASE_BRANCH}
           echo STATUS="Synced" >> $GITHUB_ENV
 
-      - name: Create PR in ${{ secrets.FORK_REPOSITORY_ORGANISATION }}/${{ secrets.FORK_REPOSITORY_NAME }}
+
+      - name: Checkout OpenCRVS Farajaland repository
         if: steps.sync_fork.outcome == 'failure'
-        id: create_pr
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: '${{ vars.FORK_REPOSITORY_ORGANISATION }}/${{ vars.FORK_REPOSITORY_NAME }}'
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - if: steps.sync_fork.outcome == 'failure'
+        name: Set up Farajaland Git repository
         run: |
-          echo "The 'sync_fork' step failed. Creating a PR in ${SYNC_FORK_REPOSITORY_PATH}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config pull.rebase true
+          git config --global url."https://${{ secrets.FORK_ORGANISATION_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+          git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | \
+              xargs -L1 git config --unset-all
+
+      - if: steps.sync_fork.outcome == 'failure'
+        name: Merge changes from upstream
+        id: merge
+        continue-on-error: true
+        run: |
+          git remote add upstream https://github.com/${UPSTREAM_REPOSITORY}.git
+          git fetch upstream
+          git checkout -b sync-with-${BASE_BRANCH}
+          git merge upstream/${BASE_BRANCH}
+
+      - if: steps.merge.outcome == 'failure'
+        name: Handle merge conflicts
+        run: |
+          git add -A
+          git commit -m "Merge upstream/${BASE_BRANCH} into sync-with-${BASE_BRANCH} with conflicts"
+          echo "Push to sync-with-${BASE_BRANCH}"
+          git remote -v
+          git push --force origin sync-with-${BASE_BRANCH}
+
+      - name: Create PR in ${{ env.FORK_REPOSITORY_ORGANISATION }}/${{ env.FORK_REPOSITORY_NAME }}
+        if: steps.sync_fork.outcome == 'failure'
+        run: |
           if gh pr create \
             --repo ${FORK_REPOSITORY_PATH} \
             --base ${BASE_BRANCH} \
-            --head opencrvs:${BASE_BRANCH} \
+            --head sync-with-${BASE_BRANCH} \
             --title "Update Farajaland from ${BASE_BRANCH}" \
             --body \
           """
           This PR updates the ${BASE_BRANCH} branch with the latest changes from
-          the original repository https://github.com/${{ github.repository }}.
+          the original repository https://github.com/${UPSTREAM_REPOSITORY}.
           """ 1>result.txt 2>&1; then
               printf "PR created successfully: $(grep ${FORK_REPOSITORY_PATH} result.txt)\n"
               echo RESULT=$(grep ${FORK_REPOSITORY_PATH} result.txt) >> $GITHUB_ENV
@@ -87,37 +124,34 @@ jobs:
                   printf "PR already exists in Farajaland repo: $(grep ${FORK_REPOSITORY_PATH} result.txt)\n"
                   echo RESULT=$(grep ${FORK_REPOSITORY_PATH} result.txt) >> $GITHUB_ENV
                   echo STATUS="Created" >> $GITHUB_ENV
-              elif grep -q "No commits" result.txt; then
-                  printf "No commits between branches: $(cat result.txt)\n"
-                  echo RESULT=$(cat result.txt) >> $GITHUB_ENV
-                  echo STATUS="NoChange" >> $GITHUB_ENV
               else
                   echo "Failed to create PR: $(cat result.txt)"
                   echo RESULT=$(cat result.txt) >> $GITHUB_ENV
                   echo STATUS="Failed" >> $GITHUB_ENV
               fi
           fi
+
       - name: Send slack notification
-        if: steps.sync_fork.outcome == 'failure'
         run: |
-          ([ "x$STATUS" == "xSynced" ] || [ "x$STATUS" == "xNoChange" ]) && \
-              echo "No need to create PR: $RESULT" && exit 0
+          [ "x$STATUS" == "xSynced" ] && \
+              echo "✅ Changes synced with Farajaland repo https://github.com/${FORK_REPOSITORY_PATH}" && \
+              exit 0
           [ "x$STATUS" == "xCreated" ] && \
               FORK_STATUS="⚠️ Changes was not synced with Farajaland repo due to merge conflicts, please merge PR $RESULT manually to keep Farajaland in sync Countryconfig"
           [ "x$STATUS" == "xFailed" ] && \
               FORK_STATUS="❌ Failed to create PR in Farajaland repository: $RESULT"
           BODY="""
-          Pull request https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
-          authored by ${{ github.actor }} from branch ${{ github.head_ref }} was merged into ${BASE_BRANCH}.
+          🚀 Pull request https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+          authored by 👤 <https://github.com/${{ github.actor }}|@${{ github.actor }}> from branch ${{ github.head_ref }} was merged into ${BASE_BRANCH}.
 
           $FORK_STATUS
           """
           echo "$BODY"
 
-          # curl -X POST https://slack.com/api/chat.postMessage \
-          # -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-          # -H 'Content-type: application/json' \
-          # --data "{
-          #   'channel': 'C02LU432JGK',
-          #   'text': '$BODY'
-          # }"
+          curl -X POST https://slack.com/api/chat.postMessage \
+          -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+          -H 'Content-type: application/json' \
+          --data "{
+            'channel': '${{ vars.SLACK_BOT_CHANNEL }}',
+            'text': '$BODY'
+          }"


### PR DESCRIPTION
This PR is follow up to https://github.com/opencrvs/opencrvs-countryconfig/pull/450

# Why This PR was created?

`gh` doesn't allow properly create PR between fork and upstream repositories within the same organisation.

# Changes to previous PR https://github.com/opencrvs/opencrvs-countryconfig/pull/450:
- Notifications are not send on success sync with Farajaland.
- Previously PR was created from upstream/branch to farajaland/branch. Now workflow creates sync-branch in Farajaland from upstream/branch. PR is created from farajaland/sync-branch to farajaland/branch
- Moved slack channel hardcode to variables

# Test results
- Success sync without conflicts: https://github.com/opencrvs/opencrvs-countryconfig/actions/runs/13626229499/job/38083968779
- Conflicts detected: https://github.com/opencrvs/opencrvs-countryconfig/actions/runs/13626550275/job/38084902989
<img width="1120" alt="image" src="https://github.com/user-attachments/assets/0bf71332-3d74-4d67-ba61-c5ad2ea49407" />

Link to slack messages: https://opencrvsworkspace.slack.com/archives/C08FCLKER8X/p1740990777223949
