### PR TITLE
fix: Deprecating save-state and set-output commands (#8798)

### DIFF
--- a/.github/workflows/get-secret-from-environment.yml
+++ b/.github/workflows/get-secret-from-environment.yml
@@ -62,10 +62,10 @@ jobs:
                             "https://api.github.com/repos/${{ github.repository }}/environments/$ENV_NAME")
           if echo "$RESPONSE" | grep -q '"name": "'$ENV_NAME'"'; then
             echo "Environment $ENV_NAME exists."
-            echo "::set-output name=exists::true"
+            echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "Environment $ENV_NAME does not exist."
-            echo "::set-output name=exists::false"
+            echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
   fetch-credentials:


### PR DESCRIPTION
This PR provides fix for https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Related issue is: https://github.com/opencrvs/opencrvs-core/issues/8798

More information how to keep variables backward compatible are here: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter

General rule is:
Replace 
```
echo "::set-output name=<key>::<value>"
```
With
```yaml
echo "<key>=<value>" >> $GITHUB_OUTPUT
```

Access results by the same way:
```
echo ${{ steps.<action step>.outputs.<key> }}
```