### PR TITLE
Fix sync changes from countryconfig to Farajaland

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -82,10 +82,10 @@ jobs:
       - if: steps.merge.outcome == 'failure'
         name: Handle merge conflicts and push opencrvs-farajaland/sync-with-${{ github.event.pull_request.base.ref }}
         run: |
-          git add -A
-          git commit -m "Merge upstream/${BASE_BRANCH} into sync-with-${BASE_BRANCH} with conflicts"
+          git merge --abort
+          git checkout upstream/${BASE_BRANCH}
           git checkout -b sync-with-${BASE_BRANCH}
-          git push --force origin sync-with-${BASE_BRANCH}
+          git push --force --set-upstream origin sync-with-${BASE_BRANCH}
 
       - name: Create PR in opencrvs-farajaland repository
         if: steps.merge.outcome == 'failure'

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -85,7 +85,7 @@ jobs:
           git merge --abort
           git checkout upstream/${BASE_BRANCH}
           git checkout -b sync-with-${BASE_BRANCH}
-          git push --force --set-upstream origin sync-with-${BASE_BRANCH}
+          git push --set-upstream origin sync-with-${BASE_BRANCH}
 
       - name: Create PR in opencrvs-farajaland repository
         if: steps.merge.outcome == 'failure'


### PR DESCRIPTION
# Test results

Goal of this PR is to improve handling conflicts in automatic PRs.

Automatic sync from countryconfig to Farajaland has 2 flows:
- No conflicts between develop branches
- Farajaland branch has conflicts and merge from countryconfig is not possible

First path was well tested within last 2 weeks, second pass was not properly handled. PRs were created, but branch conflicts were ignored: https://github.com/opencrvs/opencrvs-farajaland/pull/1283/files <img width="1442" alt="image" src="https://github.com/user-attachments/assets/b4b4b03d-9dce-40b3-8340-ea5e09c7e301" />

This PR fixes behavior for second path, example run: https://github.com/opencrvs/opencrvs-farajaland/pull/1285

<img width="946" alt="image" src="https://github.com/user-attachments/assets/7f1df73b-0741-427a-8e98-0633fc244c3c" />
