### PR TITLE
fix: Add branch name tag

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           DOCKERHUB_ACCOUNT: ${{ secrets.DOCKERHUB_ACCOUNT }}
           DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_REPO }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           # Check if the current commit has a tag and use it; otherwise, use the short SHA of the HEAD commit
           export COUNTRY_CONFIG_VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short=7 HEAD)

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -11,3 +11,11 @@ set -e
 
 docker compose build
 docker compose push
+
+# Push additional image tag if branch is develop
+if [ "x$BRANCH_NAME" == "xdevelop" ]
+then
+  docker tag ${DOCKERHUB_ACCOUNT}/${DOCKERHUB_REPO}:${COUNTRY_CONFIG_VERSION} \
+  ${DOCKERHUB_ACCOUNT}/${DOCKERHUB_REPO}:$BRANCH_NAME
+  docker push ${DOCKERHUB_ACCOUNT}/${DOCKERHUB_REPO}:$BRANCH_NAME
+fi

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/toolkit": "1.8.0-rc.c7e654c",
+    "@opencrvs/toolkit": "1.8.0-rc.b497bb6",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",
     "@types/fhir": "^0.0.30",

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,10 +834,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opencrvs/toolkit@1.8.0-rc.c7e654c":
-  version "1.8.0-rc.c7e654c"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.8.0-rc.c7e654c.tgz#a574cf992661ebfbaf745764fd7f998451659d90"
-  integrity sha512-PRkI5Un1mUuTTclZxrp0mtqpTnfmy2sR6UFZPm5FwBIIeJYSwn11gMO6dSK34/nr24ehO7tRBOb6oissesvisw==
+"@opencrvs/toolkit@1.8.0-rc.b497bb6":
+  version "1.8.0-rc.b497bb6"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.8.0-rc.b497bb6.tgz#581d8cef3615f5c676d8ae8393d6b2c6927ce978"
+  integrity sha512-AKL4qZ3VyZCTD5IjRQpAoWc6+XIwO0NJP8ze94IpdmCm6zB06tj+lVNT4aXIiTgW7GUY5j9aWGXJFpa5bdT6mw==
   dependencies:
     "@trpc/client" "^11.0.0-rc.648"
     "@trpc/server" "^11.0.0-rc.532"
@@ -5063,7 +5063,7 @@ string-argv@^0.0.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
   integrity sha512-p6/Mqq0utTQWUeGMi/m0uBtlLZEwXSY3+mXzeRRqw7fz5ezUb28Wr0R99NlfbWaMmL/jCyT9be4jpn7Yz8IO8w==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5088,6 +5088,15 @@ string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^4.1.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -5114,7 +5123,7 @@ stringify-object@^3.2.2:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5134,6 +5143,13 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"


### PR DESCRIPTION
This PR is a small piece of bigger changes: https://github.com/opencrvs/infrastructure

Soon we are going to introduce kubernetes support for OpenCRVS local development environment and cluster.

As part of introduces feature developers should be able to run opencrvs countryconfig without opencrvs core and vice versa. To be able to run it we need give developers stable image tag build from development branch, people will always know what to put in image tags.


# Test results

Pipeline: https://github.com/opencrvs/opencrvs-countryconfig/actions/runs/13990690689

The only active branch for opencrvs-countryconfig project is `develop`

https://hub.docker.com/repository/docker/opencrvs/ocrvs-countryconfig/tags?name=develop-tmp
<img width="1429" alt="image" src="https://github.com/user-attachments/assets/562f83ba-a53a-4ef3-b16a-674ff498b94d" />
