### PR TITLE
fix: Delete all indices on elasticsearch

### DIFF
--- a/infrastructure/clear-all-data.sh
+++ b/infrastructure/clear-all-data.sh
@@ -1,4 +1,5 @@
 
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -86,7 +87,14 @@ drop_database performance;
 
 # Delete all data from elasticsearch
 #-----------------------------------
-docker run --rm --network=$NETWORK appropriate/curl curl -XDELETE "http://$(elasticsearch_host)/ocrvs" -v
+indices=$(docker run --rm --network=$NETWORK appropriate/curl curl -sS -XGET "http://$(elasticsearch_host)/_cat/indices?h=index")
+echo "--------------------------"
+echo "🧹 cleanup for indices from $(elasticsearch_host): $indices"
+echo "--------------------------"
+for index in ${indices[@]}; do
+  echo "Removing index $index"
+  docker run --rm --network=$NETWORK appropriate/curl curl -sS -XDELETE "http://$(elasticsearch_host)/$index"
+done
 
 # Delete all data from metrics
 #-----------------------------
@@ -100,7 +108,7 @@ docker run --rm --network=$NETWORK --entrypoint=/bin/sh minio/mc -c "\
   mc rb myminio/ocrvs && \
   mc mb myminio/ocrvs"
 
-# Delete all data from metabase
+# Restart events service
 #-----------------------------
-docker exec $(docker ps | grep opencrvs_dashboards | awk '{print $1}' | head -n 1) /bin/sh -c "rm -rf /data/metabase/*"
-
+docker service scale opencrvs_events=0
+docker service scale opencrvs_events=1


### PR DESCRIPTION
Goal of this PR is to fix error:
```
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"The provided expression [ocrvs] matches an alias, specify the corresponding concrete indices instead."}],"type":"illegal_argument_exception","reason":"The provided expression [ocrvs] matches an alias, specify the corresponding concrete indices instead."},"status":400}{"results":[{"statement_id":0}]}
```

https://github.com/opencrvs/opencrvs-farajaland/blob/0258a786ba5d21690aeeda590104f1a80eee4d5b/infrastructure/clear-all-data.sh#L89-L90


Test results: https://github.com/adskyiproger/opencrvs-vadymland/actions/runs/14086430997/job/39451617192