### PR TITLE
chore: add translation and template fixes

### DIFF
--- a/src/api/certificates/source/v2.tennis-club-membership-certificate.svg
+++ b/src/api/certificates/source/v2.tennis-club-membership-certificate.svg
@@ -14,7 +14,7 @@
       <tspan x="62" y="447.552">Place of certification&#10;</tspan>
     </text>
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0em">
-      <tspan x="62" y="494.104">12345678912345678912345678900</tspan>
+      <tspan x="62" y="494.104">{{ lookup $state "id" }}</tspan>
     </text>
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" font-weight="bold" letter-spacing="0em">
       <tspan x="62" y="482.104">Application ID</tspan>
@@ -22,7 +22,9 @@
     <path d="M498.965 404.396H316.826V472.396H498.965V404.396Z" fill="url(#pattern0_5_2)" fill-opacity="0.2" />
     <path d="M309.793 475.396L505.999 476.321" stroke="#CCCCCC" stroke-width="0.782258" stroke-dasharray="3.13 1.56" />
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0em">
-      <tspan x="366.248" y="489.656">Registrar Jude Hopper</tspan>
+      <tspan x="366.248" y="489.656">
+        Registrar {{ findUserById (lookup $references "users") (lookup $state "updatedBy") }}
+      </tspan>
     </text>
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0em">
       <tspan x="62" y="359.604">I certify that this certificate is a true copy of the civil registry and is issued by the mandated authority in </tspan>
@@ -36,7 +38,7 @@
     <path d="M50 700H535" stroke="#C86E00" stroke-width="2" stroke-linecap="round" />
     <path d="M50 184H534" stroke="#C86E00" stroke-width="2" stroke-linecap="round" />
     <text fill="#C86E00" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="10" font-weight="bold" letter-spacing="0em">
-      <tspan x="215.483" y="199.76">No. 2023HSND234S</tspan>
+      <tspan x="215.483" y="199.76">No. {{ lookup $state "registrationNumber" }}</tspan>
     </text>
     <path d="M50 206H534" stroke="#C86E00" stroke-width="2" stroke-linecap="round" />
     <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="10" font-weight="bold" letter-spacing="0em">

--- a/src/form/v2/birth/forms/print-certificate.ts
+++ b/src/form/v2/birth/forms/print-certificate.ts
@@ -21,7 +21,8 @@ import { informantOtherThanParent, InformantType } from './pages/informant'
 const CertCollectorType = {
   INFORMANT: 'INFORMANT',
   OTHER: 'OTHER',
-  PRINT_IN_ADVANCE: 'PRINT_IN_ADVANCE'
+  MOTHER: 'MOTHER',
+  FATHER: 'FATHER'
 } as const
 
 const otherIdType = {
@@ -62,26 +63,34 @@ export const BIRTH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
             {
               label: {
                 id: 'v2.event.birth.action.certificate.form.section.requester.informant.label',
-                defaultMessage: 'Print and issue Informant',
+                defaultMessage: 'Print and issue to informant',
                 description: 'This is the label for the field'
               },
               value: CertCollectorType.INFORMANT
             },
             {
               label: {
-                id: 'v2.event.birth.action.certificate.form.section.requester.other.label',
-                defaultMessage: 'Print and issue someone else',
+                id: 'v2.event.birth.action.certificate.form.section.requester.mother.label',
+                defaultMessage: 'Print and issue to mother',
                 description: 'This is the label for the field'
               },
-              value: CertCollectorType.OTHER
+              value: CertCollectorType.MOTHER
             },
             {
               label: {
-                id: 'v2.event.birth.action.certificate.form.section.requester.printInAdvance.label',
-                defaultMessage: 'Print in advance',
+                id: 'v2.event.birth.action.certificate.form.section.requester.father.label',
+                defaultMessage: 'Print and issue to father',
                 description: 'This is the label for the field'
               },
-              value: CertCollectorType.PRINT_IN_ADVANCE
+              value: CertCollectorType.FATHER
+            },
+            {
+              label: {
+                id: 'v2.event.birth.action.certificate.form.section.requester.other.label',
+                defaultMessage: 'Print and issue to someone else',
+                description: 'This is the label for the field'
+              },
+              value: CertCollectorType.OTHER
             }
           ]
         },
@@ -97,7 +106,9 @@ export const BIRTH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
           conditionals: [
             {
               type: ConditionalType.SHOW,
-              conditional: field('collector.requesterId').isEqualTo('OTHER')
+              conditional: field('collector.requesterId').isEqualTo(
+                CertCollectorType.OTHER
+              )
             }
           ],
           options: [
@@ -321,7 +332,9 @@ export const BIRTH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
     {
       id: 'collector.identity.verify',
       type: PageTypes.enum.VERIFICATION,
-      conditional: field('collector.requesterId').isEqualTo('INFORMANT'),
+      conditional: field('collector.requesterId').isEqualTo(
+        CertCollectorType.INFORMANT
+      ),
       title: {
         id: 'event.birth.action.print.verifyIdentity',
         defaultMessage: 'Verify their identity',

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -2604,7 +2604,7 @@ v2.event.birth.summary.informant.contact.label,This is the label for the informa
 v2.event.birth.summary.informant.contact.value,This is the contact value of the informant,{informant.phoneNo} {informant.email},{informant.phoneNo} {informant.email}
 v2.event.birth.summary.title,This is the title of the summary,{child.firstname} {child.surname},{child.firstname} {child.surname}
 v2.event.birth.workqueue.all.name.label,Label for name in all workqueue,{child.surname} {child.firstname},{child.surname} {child.firstname}
-v2.event.default.action.certificate.form.section.who.field.surname.label,This is the label for the field,Select Certificate Template,Select Certificate Template
+v2.event.default.action.certificate.template.type.label,Select certificate template,Type,Taper
 v2.event.history.markAsDuplicate,,Marked as a duplicate,Marqué comme doublon
 v2.event.history.role,Label for the role in event history,"{role, select, LOCAL_REGISTRAR{Local Registrar} other{Unknown}}","{role, select, LOCAL_REGISTRAR{Registraire local} other{Inconnu}}"
 v2.event.summary.event.label,Label for the event field,Event,Événement


### PR DESCRIPTION
Changes: 
- Update translation id
- Remove print in advance option until it's implemented
- Allow MOTHER/FATHER selection
- Update tennis club certificate