### PR TITLE
fix: Added readme to resources menu;

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -22,6 +22,13 @@ countryconfig_image_tag="local"
 opencrvs_namespace = 'opencrvs-dev'
 dependencies_namespace = 'opencrvs-deps-dev'
 
+
+# Checkout infrastructure directory if not exists
+if not os.path.exists('../infrastructure'):
+    local("git clone git@github.com:opencrvs/infrastructure.git ../infrastructure")
+
+local_resource('README.md', cmd='awk "/For OpenCRVS Country Config Developers/{flag=1; next} /Seed data/{flag=0} flag" ../infrastructure/README.md', labels=['0.Readme'])
+
 ############################################################
 # What common Tiltfile does?
 # - Group resources by label on UI: http://localhost:10350/
@@ -49,9 +56,6 @@ namespace_create('traefik')
 namespace_create(dependencies_namespace)
 namespace_create(opencrvs_namespace)
 
-# Checkout infrastructure directory if not exists
-if not os.path.exists('../infrastructure'):
-    local("git clone git@github.com:opencrvs/infrastructure.git ../infrastructure")
 
 # Install Traefik GW
 helm_repo('traefik-repo', 'https://traefik.github.io/charts', labels=['Dependencies'])

--- a/Tiltfile
+++ b/Tiltfile
@@ -6,6 +6,8 @@
 # - v1.7.0
 # - v1.7.1
 # NOTE: It could take any value from https://github.com/orgs/opencrvs/packages
+# If you are under opencrvs-core repository, please use "local" tag
+# Tilt will build new image every time when changes are made to repository
 core_images_tag="develop"
 
 # Countryconfig/Farajaland image repository and tag
@@ -14,8 +16,8 @@ core_images_tag="develop"
 # you local registry
 # (see: https://medium.com/@ankitkumargupta/quick-start-local-docker-registry-35107038242e)
 countryconfig_image_name="opencrvs/ocrvs-countryconfig"
-# Usually image tag value is set to "local", Tilt will build new
-# image every time when changes are made to repository
+# If you are under opencrvs-countryconfig or your own repository, please use "local" tag,
+# Tilt will build new image every time when changes are made to repository
 countryconfig_image_tag="local"
 
 # Namespaces:
@@ -34,9 +36,7 @@ local_resource('README.md', cmd='awk "/For OpenCRVS Country Config Developers/{f
 # - Group resources by label on UI: http://localhost:10350/
 include('../infrastructure/tilt/Tiltfile.common')
 
-# Load extensions for configmap/secret/namespace operations
-load('ext://configmap', 'configmap_create')
-load('ext://secret', 'secret_create_generic', 'secret_from_dict', 'secret_create_tls')
+# Load extensions for namespace and helm operations
 load('ext://namespace', 'namespace_create', 'namespace_inject')
 load('ext://helm_resource', 'helm_resource', 'helm_repo')
 


### PR DESCRIPTION
This PR contains following fixes:
- Added README.md from infrastructure repository
  <img width="1451" alt="image" src="https://github.com/user-attachments/assets/98684ca5-192c-455e-b7f1-8b8bdf8a430a" />
- Fix: If infrastructure directory doesn't exist clone repository before including Tiltfile.common