### PR TITLE
add validation to informant nid

### DIFF
--- a/src/form/v2/birth/forms/pages/father.ts
+++ b/src/form/v2/birth/forms/pages/father.ts
@@ -251,13 +251,13 @@ export const father = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.father}.nid`,
+      id: 'father.nid',
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'ID Number',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.nid.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.nid.label'
       },
       conditionals: [
         {
@@ -275,9 +275,18 @@ export const father = defineFormPage({
             defaultMessage:
               'ID Number must be different from mother`s ID Number',
             description: 'This is the error message for non-unique ID Number',
-            id: `v2.event.birth.action.declare.form.father.nid.unique`
+            id: 'v2.event.birth.action.declare.form.nid.unique.mother'
           },
           validator: not(field('father.nid').isEqualTo(field('mother.nid')))
+        },
+        {
+          message: {
+            defaultMessage:
+              'ID Number must be different from informant`s ID Number',
+            description: 'This is the error message for non-unique ID Number',
+            id: 'v2.event.birth.action.declare.form.nid.unique.informant'
+          },
+          validator: not(field('father.nid').isEqualTo(field('informant.nid')))
         }
       ]
     },

--- a/src/form/v2/birth/forms/pages/informant.ts
+++ b/src/form/v2/birth/forms/pages/informant.ts
@@ -20,7 +20,10 @@ import {
 } from '@opencrvs/toolkit/events'
 import { field, not } from '@opencrvs/toolkit/conditionals'
 import { createSelectOptions, emptyMessage } from '../../../utils'
-import { MAX_NAME_LENGTH } from '@countryconfig/form/v2/birth/validators'
+import {
+  MAX_NAME_LENGTH,
+  nationalIdValidator
+} from '@countryconfig/form/v2/birth/validators'
 import { IdType, idTypeOptions, PersonType } from '../../../person'
 
 export const InformantType = {
@@ -278,23 +281,42 @@ export const informant = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.informant}.nid`,
+      id: 'informant.nid',
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'ID Number',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.nid.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.nid.label'
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.informant}.idType`).isEqualTo(
-              IdType.NATIONAL_ID
-            ),
+            field('informant.idType').isEqualTo(IdType.NATIONAL_ID),
             informantOtherThanParent
           )
+        }
+      ],
+      validation: [
+        nationalIdValidator('informant.nid'),
+        {
+          message: {
+            defaultMessage:
+              'ID Number must be different from fathers`s ID Number',
+            description: 'This is the error message for non-unique ID Number',
+            id: `v2.event.birth.action.declare.form.nid.unique.father`
+          },
+          validator: not(field('informant.nid').isEqualTo(field('father.nid')))
+        },
+        {
+          message: {
+            defaultMessage:
+              'ID Number must be different from mothers`s ID Number',
+            description: 'This is the error message for non-unique ID Number',
+            id: `v2.event.birth.action.declare.form.nid.unique.mother`
+          },
+          validator: not(field('informant.nid').isEqualTo(field('mother.nid')))
         }
       ]
     },

--- a/src/form/v2/birth/forms/pages/mother.ts
+++ b/src/form/v2/birth/forms/pages/mother.ts
@@ -272,9 +272,18 @@ export const mother = defineFormPage({
             defaultMessage:
               'ID Number must be different from fathers`s ID Number',
             description: 'This is the error message for non-unique ID Number',
-            id: `v2.event.birth.action.declare.form.mother.nid.unique`
+            id: 'v2.event.birth.action.declare.form.nid.unique.father'
           },
           validator: not(field('mother.nid').isEqualTo(field('father.nid')))
+        },
+        {
+          message: {
+            defaultMessage:
+              'ID Number must be different from informant`s ID Number',
+            description: 'This is the error message for non-unique ID Number',
+            id: 'v2.event.birth.action.declare.form.nid.unique.informant'
+          },
+          validator: not(field('mother.nid').isEqualTo(field('informant.nid')))
         }
       ]
     },


### PR DESCRIPTION
## Description

Informant National ID was missing validation.

Also add validation to mother/father nid to make sure its not same as informant.

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
