### PR TITLE
Verify a worker to be added to docker swarm is not part of some other swarm

### DIFF
--- a/infrastructure/server-setup/swarm.yml
+++ b/infrastructure/server-setup/swarm.yml
@@ -29,26 +29,39 @@
       shell: docker swarm join-token -q worker
       register: worker_token
 
-  
+
 - hosts: docker-workers
   become: yes
   become_method: sudo
   vars:
     manager_hostname: "{{ groups['docker-manager-first'][0] }}"
   tasks:
-    - name: Check if the node is already part of any swarm
+    - name: Check if the node is part of any swarm
       shell: docker info --format "{% raw %}{{.Swarm.LocalNodeState}}{% endraw %}"
       register: worker_swarm_status
       changed_when: false
 
-    - name: Fail if the node is already part of a swarm
-      fail:
-        msg: "You are trying to attach a worker to a Swarm that is already part of another Swarm. Please make the node leave the current Swarm first, then run the playbook again."
-      when: "worker_swarm_status.stdout.find('active') != -1"
+    - name: Get NodeID of the worker (if part of a swarm)
+      shell: docker info --format "{% raw %}{{.Swarm.NodeID}}{% endraw %}"
+      register: worker_node_id
+      when: worker_swarm_status.stdout == 'active'
+      changed_when: false
+      failed_when: false
 
-    - name: 'Join as a worker'
+    - name: Get list of nodes in the manager's swarm
+      shell: docker node ls --format '{% raw %}{{.ID}}{% endraw %}'
+      delegate_to: "{{ manager_hostname }}"
+      register: manager_node_ids
+      changed_when: false
+
+    - name: Fail if the worker is in a different swarm
+      fail:
+        msg: "Worker is already part of a different swarm cluster."
+      when: worker_swarm_status.stdout == 'active' and worker_node_id.stdout not in manager_node_ids.stdout_lines
+
+    - name: Join as a worker
       shell: "docker swarm join --token {{ hostvars[manager_hostname]['worker_token']['stdout'] }} {{ hostvars[manager_hostname]['ansible_default_ipv4']['address'] }}:2377"
-      when: "docker_info.stdout.find('Swarm: inactive') != -1"
+      when: worker_swarm_status.stdout != 'active'
       retries: 3
       delay: 20
 

--- a/infrastructure/server-setup/swarm.yml
+++ b/infrastructure/server-setup/swarm.yml
@@ -56,7 +56,7 @@
 
     - name: Fail if the worker is in a different swarm
       fail:
-        msg: "Worker is already part of a different swarm cluster."
+        msg: "You are trying to attach a worker to a Swarm that is already part of another Swarm. Please make the node leave the current Swarm first, then run the playbook again."
       when: worker_swarm_status.stdout == 'active' and worker_node_id.stdout not in manager_node_ids.stdout_lines
 
     - name: Join as a worker


### PR DESCRIPTION
## Description

This was a bug we discovered while doing other development of our pipelines. The issue is
1. Provision a cluster with 2 nodes
2. Run ansible provisioning again
3. Notice there's an error now as the swarm node already belongs to the swarm

**Expectation**
Joining the worker is skipped silently as it doesn't need to be done. Only when the node is a part of **some other** swarm, the error would need to be thrown

**Actual**
The logic incorrectly interprets the situation as an error and throws an exception. 

## Checklist

- [x] I have tested the changes locally, and written appropriate tests

Clean slate provision of manager + worker: :white_check_mark: 
Rerun without code changes: :collision: 
Rerun with code changes: :white_check_mark: 
Rerun with worker attached to a swarm of its own: :collision:
Removed the worker from its own swarm and rerun: :white_check_mark:

- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
