### PR TITLE
hide informant exact date of birth unknown

### DIFF
--- a/src/form/v2/birth/forms/pages/informant.ts
+++ b/src/form/v2/birth/forms/pages/informant.ts
@@ -15,6 +15,7 @@ import {
   ConditionalType,
   defineFormPage,
   FieldType,
+  never,
   or,
   TranslationConfig
 } from '@opencrvs/toolkit/events'
@@ -217,6 +218,10 @@ export const informant = defineFormPage({
         {
           type: ConditionalType.SHOW,
           conditional: informantOtherThanParent
+        },
+        {
+          type: ConditionalType.DISPLAY_ON_REVIEW,
+          conditional: never()
         }
       ]
     },


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/issues/9159#issuecomment-2812733350

Hide informant exact date of birth checkbox from review.

## Checklist

- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
