### PR TITLE
fix: "Match all" section should be present after "Match User..."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.7.1 Release candidate
 
 ### Bug fixes
-
+- "Match all" section should be present after "Match User..." in sshd_config [#653](https://github.com/opencrvs/opencrvs-countryconfig/pull/653)
 
 ## 1.7.0
 

--- a/infrastructure/server-setup/tasks/users.yml
+++ b/infrastructure/server-setup/tasks/users.yml
@@ -150,6 +150,7 @@
       Match User {{ ansible_user }}
         PasswordAuthentication no
         AuthenticationMethods publickey
+      Match all
     marker: '# {mark} ANSIBLE MANAGED BLOCK FOR USER {{ ansible_user }}'
   become: yes
 


### PR DESCRIPTION
## Description

If environment was provisioned from version v1.8.0+ and later re-provisioned with older versions v1.7.0+, the provision script fails on ssh config update step due to syntax error in sshd_config.

"Match all" section should be present after "Match User..." in sshd_config

Configuration file snippet:
```
# BEGIN ANSIBLE MANAGED BLOCK FOR USER provision
Match User provision
  PasswordAuthentication no
  AuthenticationMethods publickey
Match all
# END ANSIBLE MANAGED BLOCK FOR USER provision
HostKey /etc/ssh/ssh_host_ed25519_key
HostKey /etc/ssh/ssh_host_rsa_key
```

Without `Match all` section sshd will fail to start with syntax error, example from provision script:
```
TASK [Check SSH config syntax] *************************************************
fatal: [farajaland-qa]: FAILED! => {"changed": true, "cmd": ["sshd", "-T"], "delta": "0:00:00.014118", "end": "2025-04-23 11:47:02.563045", "msg": "non-zero return code", "rc": 255, "start": "2025-04-23 11:47:02.548927", "stderr": "/etc/ssh/sshd_config line 130: Directive 'HostKey' is not allowed within a Match block", "stderr_lines": ["/etc/ssh/sshd_config line 130: Directive 'HostKey' is not allowed within a Match block"], "stdout": "", "stdout_lines": []}
...ignoring
```

See https://github.com/opencrvs/opencrvs-farajaland/actions/runs/14617145539/job/41007973930

## Checklist

- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
