### PR TITLE
fix: Cache service responded with 422

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,11 @@ jobs:
       - name: Checking out git repo
         uses: actions/checkout@v4
 
-      - name: Use Node.js 18.19
-        uses: actions/setup-node@v2
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.19'
-          cache: 'npm'
+          node-version-file: .nvmrc
+          cache: 'yarn'
 
       - name: Runs dependency installation
         run: yarn


### PR DESCRIPTION
## Description

We are using yarn package manager, npm cache is empty:
![image](https://github.com/user-attachments/assets/692a5f78-deb9-4388-b8df-58fcbe32b339)

Cache remains empty after `yarn install`:
![image](https://github.com/user-attachments/assets/9479e252-ef78-482f-9b9a-e423fdc29799)

## Checklist

- [ ] I have tested the changes locally, and written appropriate tests
       ![image](https://github.com/user-attachments/assets/d6967dd3-af7b-4ed2-92b6-df3608bb8573)
       ![image](https://github.com/user-attachments/assets/4442c4fb-7c27-4d3e-b894-70b24e132ff7)
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
