### PR TITLE
fix: create separate configuration for each informant type

### DIFF
--- a/src/form/v2/birth/forms/pages/informant.ts
+++ b/src/form/v2/birth/forms/pages/informant.ts
@@ -378,7 +378,10 @@ const getInformantCommonFields = (
       conditionals: [
         {
           type: ConditionalType.SHOW,
-          conditional: informantOtherThanParent
+          conditional: and(
+            informantOtherThanParent,
+            field('informant.relation').isEqualTo(informantType)
+          )
         }
       ]
     },
@@ -394,7 +397,10 @@ const getInformantCommonFields = (
       conditionals: [
         {
           type: ConditionalType.SHOW,
-          conditional: informantOtherThanParent
+          conditional: and(
+            informantOtherThanParent,
+            field('informant.relation').isEqualTo(informantType)
+          )
         }
       ]
     },
@@ -431,7 +437,10 @@ const getInformantCommonFields = (
       conditionals: [
         {
           type: ConditionalType.SHOW,
-          conditional: informantOtherThanParent
+          conditional: and(
+            informantOtherThanParent,
+            field('informant.relation').isEqualTo(informantType)
+          )
         }
       ]
     },


### PR DESCRIPTION
## Description
In order to reset fields based on another field, configure and render informant type specific fields

![informant-form-state](https://github.com/user-attachments/assets/78410a9e-1ec3-4e5b-9a1c-71d7070641ae)
