### PR TITLE
fix (v.1.6.4): Add HEARTH_MONGO_URL to docker compose files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.6.4
 
+### Bug fixes
+
+- Query the location tree directly from the config service to improve performance for large datasets
+
 ## 1.6.3
 
 ### Breaking changes

--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -872,6 +872,7 @@ services:
       - APN_SERVICE_URL=http://apm-server:8200
       - CERT_PUBLIC_KEY_PATH=/run/secrets/jwt-public-key.{{ts}}
       - MONGO_URL=mongodb://config:${CONFIG_MONGODB_PASSWORD}@mongo1/application-config?replicaSet=rs0
+      - HEARTH_MONGO_URL=mongodb://hearth:${HEARTH_MONGODB_PASSWORD}@mongo1/hearth-dev?replicaSet=rs0
       - LOGIN_URL=https://login.{{hostname}}
       - CLIENT_APP_URL=https://register.{{hostname}}
       - DOMAIN={{hostname}}

--- a/infrastructure/docker-compose.staging-deploy.yml
+++ b/infrastructure/docker-compose.staging-deploy.yml
@@ -75,6 +75,7 @@ services:
       - NODE_ENV=production
       - SENTRY_DSN=${SENTRY_DSN:-}
       - MONGO_URL=mongodb://config:${CONFIG_MONGODB_PASSWORD}@mongo1/application-config?replicaSet=rs0
+      - HEARTH_MONGO_URL=mongodb://hearth:${HEARTH_MONGODB_PASSWORD}@mongo1/hearth-dev?replicaSet=rs0
     deploy:
       replicas: 1
 


### PR DESCRIPTION
Redoing the pull request as per the new hotfix flows.

Allows connecting the config service directly to Mongo for location queries.

Related issue: https://github.com/opencrvs/opencrvs-core/issues/8665 and https://github.com/opencrvs/opencrvs-core/issues/9255
