### PR TITLE
fix: Drop STACK placeholder from docker-compose

### DIFF
--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -255,9 +255,9 @@ services:
   redis:
     environment:
       - VALKEY_PASSWORD=false
-      - VALKEY_ACLFILE=/run/secrets/redis-acl.{{STACK}}.{{ts}}
+      - VALKEY_ACLFILE=/run/secrets/redis-acl.{{ts}}
     secrets:
-      - redis-acl.{{STACK}}.{{ts}}
+      - redis-acl.{{ts}}
     networks:
       - overlay_net
     deploy:
@@ -1034,7 +1034,7 @@ services:
         constraints:
           - node.labels.data1 == true
 secrets:
-  redis-acl.{{STACK}}.{{ts}}:
+  redis-acl.{{ts}}:
     external: true
   jwt-public-key.{{ts}}:
     external: true

--- a/infrastructure/rotate-secrets.sh
+++ b/infrastructure/rotate-secrets.sh
@@ -18,7 +18,7 @@ echo "$PUB_KEY" | docker secret create jwt-public-key.$UNIX_TS -
 echo "$PRIV_KEY" | docker secret create jwt-private-key.$UNIX_TS -
 
 INFRASTRUCTURE_DIRECTORY=$(dirname "$0")
-cat $INFRASTRUCTURE_DIRECTORY/redis-acl.conf | docker secret create redis-acl.$STACK.$UNIX_TS -
+cat $INFRASTRUCTURE_DIRECTORY/redis-acl.conf | docker secret create redis-acl.$UNIX_TS -
 
 sed -i "s/{{ts}}/$UNIX_TS/g" "$@"
 echo "DONE - `date --iso-8601=ns`"


### PR DESCRIPTION
## Description

This PR aims to address issue https://github.com/opencrvs/opencrvs-farajaland/actions/runs/14771582556/job/41472399233

docker-compose on e2e environment has 2 placeholders "{{STACK}}.{{ts}}" on farajaland we have only one placeholder "{{ts}}"

## Checklist

- [ ] I have linked the correct Github issue under "Development": n/a
- [ ] I have tested the changes locally, and written appropriate tests: reference PR https://github.com/opencrvs/opencrvs-farajaland/pull/1364/files and test results https://github.com/opencrvs/opencrvs-farajaland/actions/runs/14773991059/job/41479086672
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths): n/a
- [ ] I have updated the changelog with this change (if applicable): n/a
- [ ] I have updated the GitHub issue status accordingly: n/a
