### PR TITLE
Release automation: automation pipeline for bootstrapping a new release(ocrvs-9396)

### DIFF
--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -6,7 +6,7 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-name: Release - Start a new release
+name: Release - Start a new release 
 on:
   workflow_dispatch:
     inputs:
@@ -19,25 +19,82 @@ jobs:
   release_workflow:
     runs-on: ubuntu-latest
     steps:
-      - name: gitflow-workflow-action release workflows
+      - name: Determine the Base Branch
+        id: get_base_branch
+        run: |
+          version="${{ inputs.version }}"
+
+          if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version was provided as input: $version" >&2
+            echo "Please follow semver format for versioning, e/g 1.7.2"
+            exit 1
+          fi
+
+          IFS='.' read -r x y z <<< "$version"
+          if [ "$z" = "0" ]; then
+            base_branch="develop"
+          else
+            previous_version="$((x)).$((y)).$((z-1))"
+            base_branch="release/$previous_version"
+          fi
+          echo "target_branch=master" >> $GITHUB_OUTPUT
+          echo "base_branch=$base_branch" >> $GITHUB_OUTPUT
+                 
+      - name: Start a new release ${{ inputs.version }} from ${{ steps.get_base_branch.outputs.base_branch }}
         uses: hoangvvo/gitflow-workflow-action@0.3.8
         with:
-          develop_branch: "develop"
-          main_branch: "master"
+          develop_branch: ${{ steps.get_base_branch.outputs.base_branch }}
+          main_branch: ${{ steps.get_base_branch.outputs.target_branch }}
           merge_back_from_main: false
           version: ${{ inputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
+      - name: Checkout the release branch
+        uses: actions/checkout@v4
+        with:
+          ref: "release/${{ inputs.version }}"
+
       - name: Clear auto-generated PR comment
         run: |
           REPO="${{ github.repository }}"
           PR_BRANCH="release/${{ inputs.version }}"
           PR_NUMBER=$(gh pr list --head "$PR_BRANCH" --repo "$REPO" --json number -q '.[0].number')
+          cd "$GITHUB_WORKSPACE"
+          if [ -f .github/TEMPLATES/RELEASE_PR_TEMPLATE.md ]; then
+            BODY=$(jq -Rs . < .github/TEMPLATES/RELEASE_PR_TEMPLATE.md)
+          else
+            BODY=$(jq -n --arg body "" '$body')
+          fi
+          echo "{\"body\": $BODY}" > body.json
           gh api \
             --method PATCH \
             -H "Accept: application/vnd.github.v3+json" \
             /repos/"$REPO"/issues/"$PR_NUMBER" \
-            -f body=""
+            --input body.json 
+          rm body.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+      - name: Update version numbers and CHANGELOG
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          yarn version --new-version ${{ inputs.version }} --no-git-tag-version
+          git add .
+          git commit -m "chore: update version to ${{ inputs.version }}"
+
+          sed -i '1,2d' CHANGELOG.md
+          cp CHANGELOG.md COPY_CHANGELOG.md
+          {
+            echo "# Changelog"
+            echo ""
+            echo "## ${{ inputs.version }} Release Candidate"
+            echo ""
+            cat COPY_CHANGELOG.md 
+          } > CHANGELOG.md
+          git add CHANGELOG.md
+          git commit -m "docs: update changelog for ${{ inputs.version }} release candidate"
+          git push origin "release/${{ inputs.version }}"


### PR DESCRIPTION
## Description

Introducing a new workflow which will trigger a pipeline with a given version number like `1.6.4`  and have branches, PRs and a draft release created automatically

### Tech tasks
- [x] In  OpenCRVS core, create a new pipeline "Release - Start a new release". It takes one input: New release version e.g. `1.6.9`. Use [this](https://github.com/marketplace/actions/gitflow-workflow-action) action for building the pipeline
- [x] To the release PR, create one commit that changes all the version numbers in `package.json` files and creates a new heading in `CHANGELOG.md`
- [x] Base branch should be chosen based on the the input
- [x] The pipeline should also create a new draft release for the version that is being created
- [x] Make the OpenCRVS core pipeline also trigger the pipeline in country config