### PR TITLE
display fathers and mothers name as informant, display inputted relation when relation is 'Someone else'

### DIFF
--- a/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
@@ -374,8 +374,17 @@
   <g clip-path="url(#clip16_946_2501)">
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
       font-size="8" letter-spacing="0px">
-      <tspan x="307" y="518.104">{{$lookup $declaration 'informant.firstname'}} {{$lookup $declaration 'informant.surname'}}</tspan>
-      <tspan x="307" y="528.104">{{$intl 'v2.constants.informant' ($lookup $declaration 'informant.relation')}}</tspan>
+
+      {{#ifCond (lookup $declaration 'informant.relation') '===' 'MOTHER' }}
+        <tspan x="307" y="518.104">{{$lookup $declaration 'mother.firstname'}} {{$lookup $declaration 'mother.surname'}}</tspan>
+      {{ else }}
+        {{#ifCond (lookup $declaration 'informant.relation') '===' 'FATHER'}}
+          <tspan x="307" y="518.104">{{$lookup $declaration 'father.firstname'}} {{$lookup $declaration 'father.surname'}}</tspan>  
+        {{ else }}
+          <tspan x="307" y="518.104">{{$lookup $declaration 'informant.firstname'}} {{$lookup $declaration 'informant.surname'}}</tspan>
+        {{/ifCond}}
+      {{/ifCond}}
+      <tspan x="307" y="528.104">{{$intl 'v2.constants.informant' ($lookup $declaration 'informant.relation')}}{{#ifCond (lookup $declaration 'informant.relation') '===' 'OTHER'}} ({{$lookup $declaration 'informant.other.relation'}}) {{/ifCond}}</tspan>
     </text>
   </g>
   <line x1="65" y1="536.5" x2="533" y2="536.5" stroke="#ECECEC" />

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -2892,6 +2892,7 @@ v2.view.record,Label for view record,View record,Afficher l'enregistrement
 v2.wq.noRecords.CREATED,No records messages for empty draft tab,No records in progress,Aucun enregistrement en cours
 v2.wq.noRecords.DECLARED,No records messages for ready for review tab,No records ready for review,Aucun document prêt à être examiné
 v2.wq.noRecords.REGISTERED,No records messages for ready to print tab,No records ready to print,Aucun document prêt à être imprimé
+v2.errors.notAssigned,User not assigned error toast message,"You've been unassigned from the event","Vous avez été désassigné de l'événement"
 validate.complete.declaration.action.description,,The informant will receive an with a registration number that they can use to collect the certificate.,"En envoyant pour approbation, vous confirmez que la déclaration est prête à être approuvée."
 validate.complete.declaration.action.title,,Declaration complete,Envoyer pour approbation ou rejeter ?
 validate.declaration.action.modal.description,,This declaration will be sent for approval prior to registration.,Cette déclaration sera envoyée pour approbation avant l'enregistrement.


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/9556

* If informant type is mother or father, display their name in the certified copy as informant name
* If informant type is 'Someone else', display the inputted relation on the certified copy
* Add missing translation

<img width="1715" alt="Screenshot 2025-05-19 at 13 01 42" src="https://github.com/user-attachments/assets/88710c76-7fd8-4c2c-b9de-53f6785ad68b" />
<img width="1719" alt="Screenshot 2025-05-19 at 13 01 14" src="https://github.com/user-attachments/assets/83454f94-a9d7-4dbc-8e59-32b579181fc4" />


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
