### PR TITLE
fix: reverted current_user to ansible_user to avoid creation of runne…

### DIFF
--- a/infrastructure/server-setup/tasks/application.yml
+++ b/infrastructure/server-setup/tasks/application.yml
@@ -27,7 +27,7 @@
     mode: '0775'
     recurse: yes
 
-- name: Add current user to 'application' group
+- name: Add ansible user to 'application' group
   user:
     name: '{{ ansible_user }}'
     groups: application

--- a/infrastructure/server-setup/tasks/application.yml
+++ b/infrastructure/server-setup/tasks/application.yml
@@ -27,20 +27,16 @@
     mode: '0775'
     recurse: yes
 
-- name: Get the current logged in user
-  set_fact:
-    current_user: "{{ lookup('env', 'USER') }}"
-
 - name: Add current user to 'application' group
   user:
-    name: '{{ current_user }}'
+    name: '{{ ansible_user }}'
     groups: application
     append: yes
 
 - name: Create secret logfile
   ansible.builtin.file:
     path: /var/log/rotate-secrets.log
-    owner: '{{ current_user }}'
+    owner: '{{ ansible_user }}'
     group: 'application'
     state: touch
     mode: 'u+rwX,g+rwX,o-rwx'
@@ -48,7 +44,7 @@
 - name: Create backup logfile
   ansible.builtin.file:
     path: /var/log/opencrvs-backup.log
-    owner: '{{ current_user }}'
+    owner: '{{ ansible_user }}'
     group: 'application'
     state: touch
     mode: 'u+rwX,g+rwX,o-rwx'
@@ -56,7 +52,7 @@
 - name: Create backup logfile for error
   ansible.builtin.file:
     path: /var/log/opencrvs-backup.error.log
-    owner: '{{ current_user }}'
+    owner: '{{ ansible_user }}'
     group: 'application'
     state: touch
     mode: 'u+rwX,g+rwX,o-rwx'
@@ -64,7 +60,7 @@
 - name: Create restore logfile
   ansible.builtin.file:
     path: /var/log/opencrvs-restore.log
-    owner: '{{ current_user }}'
+    owner: '{{ ansible_user }}'
     group: 'application'
     state: touch
     mode: 'u+rwX,g+rwX,o-rwx'
@@ -72,7 +68,7 @@
 - name: Create reboot logfile
   ansible.builtin.file:
     path: /var/log/cryptfs-reboot.log
-    owner: '{{ current_user }}'
+    owner: '{{ ansible_user }}'
     group: 'application'
     state: touch
     mode: 'u+rwX,g+rwX,o-rwx'
@@ -80,7 +76,7 @@
 - name: Create papertrail logfile
   ansible.builtin.file:
     path: /var/log/papertrail.log
-    owner: '{{ current_user }}'
+    owner: '{{ ansible_user }}'
     group: 'application'
     state: touch
     mode: 'u+rwX,g+rwX,o-rwx'

--- a/infrastructure/server-setup/tasks/checks.yml
+++ b/infrastructure/server-setup/tasks/checks.yml
@@ -23,4 +23,4 @@
     (single_node | default(false)) == false and (
       'docker-workers' not in groups or
       groups['docker-workers'] | length == 0
-    ) 
+    )

--- a/infrastructure/server-setup/tasks/deployment-user.yml
+++ b/infrastructure/server-setup/tasks/deployment-user.yml
@@ -7,12 +7,8 @@
     name: docker
     state: present
 
-- name: Get the current logged in user
-  set_fact:
-    current_user: "{{ lookup('env', 'USER') }}"
-
 - name: Add user to Docker group
   user:
-    name: '{{ current_user }}'
+    name: '{{ ansible_user }}'
     groups: docker
     append: yes

--- a/infrastructure/server-setup/tasks/swap.yml
+++ b/infrastructure/server-setup/tasks/swap.yml
@@ -22,7 +22,7 @@
     - swap.file.mkswap
 
 - name: 'Check swap file type'
-  command: file {{ swap_file_path }}
+  command: sudo file {{ swap_file_path }}
   register: swapfile
   tags:
     - swap.file.mkswap

--- a/infrastructure/server-setup/tasks/users.yml
+++ b/infrastructure/server-setup/tasks/users.yml
@@ -239,7 +239,7 @@
     - ansible_facts['distribution_version'] == '24.04'
 
 - name: Check SSH config syntax
-  command: sshd -T
+  command: sudo sshd -T
   register: check_result
 
 - name: Enable logging in to the provisioning user with specified SSH keys


### PR DESCRIPTION
## Description

Reverted current_user to ansible_user to avoid creation of runner user.

Issue was introduced by following 
[commit](https://github.com/opencrvs/opencrvs-farajaland/commit/6f87cd9944331c6f8920044648f20a65ded00825#diff-a1acd82f252310764b8508fd98f45bfd90191ce4146c6b18df1ea19ff4be5e67)

How that issue effect server setup?
1. First run ansible is able to provision host successfully
2. Every next run ansible fails with permission denied
3. Provision user still working fine.

How to observe the issue on the server?
1. Login on any Farajaland server
2. Check /home folder, you will find 2 folders: provision and runner
    Example:
    ```
    vmudryi@farajaland-dev:~$ ls -1 /home
    ...
    provision
    ...
    runner
    ...
    ```

## Checklist

- [x] I have linked the correct Github issue under "Development": See full description in slack: https://opencrvsworkspace.slack.com/archives/C07M2FETFFB/p1747765774879999
- [ ] I have tested the changes locally, and written appropriate tests: Case for local infrastructure setup should be tested separately
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths): We should test local infrastructure setup as well
- [ ] I have updated the changelog with this change (if applicable): No need to update changelog
- [ ] I have updated the GitHub issue status accordingly: N/A
