### PR TITLE
fix: Allow running provision from other workflows

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -1,6 +1,16 @@
 name: Provision environment
 run-name: Provision ${{ github.event.inputs.environment }}
 on:
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+        description: Environment to deploy to
+        required: true
+      tag:
+        type: string
+        description: Environment to deploy to
+        default: all
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/9393

This PR aims to enable call provision workflow from other workflows.

Example call: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15211814506

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable): not relevant
- [ ] I have updated the GitHub issue status accordingly: not relevant
