### PR TITLE
fix: Added wait command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,13 @@ jobs:
 
       - name: Test
         run: yarn test
+
+      - name: Bash script linting
+        uses: ludeeus/action-shellcheck@master
+        continue-on-error: true
+        with:
+          severity: error
+          ignore_paths: |
+            node_modules/**/*
+        env:
+          SHELLCHECK_OPTS: -e SC2086 -e SC2068

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,4 +1,4 @@
-
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/infrastructure/mongodb/on-deploy.sh
+++ b/infrastructure/mongodb/on-deploy.sh
@@ -67,21 +67,19 @@ ATTEMPT=1
 
 # Initiate the replica set
 while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
-    echo "🔄 Attempt $ATTEMPT to initiate replica set..."
-    
-    if mongo $(mongo_credentials) --host mongo1 --eval "rs.initiate({_id:\"rs0\",members:${MEMBERS}})"; then
-        echo "✅ Replica set initiated successfully."
-        break
-    fi
+  echo "🔄 Attempt $ATTEMPT to initiate replica set..."
+  if mongo $(mongo_credentials) --host mongo1 --eval "rs.initiate({_id:\"rs0\",members:${MEMBERS}})"; then
+    echo "✅ Replica set initiated successfully."
+    break
+  elif [[ $ATTEMPT -eq $MAX_RETRIES ]]; then
+    echo "❌ Failed to initiate replica set after $MAX_RETRIES attempts."
+    exit 1
+  fi
 
-    echo "⏳ Failed to initiate replica set. Retrying in $DELAY seconds..."
-    sleep $DELAY
-    ((ATTEMPT++))
+  echo "⏳ Failed to initiate replica set. Retrying in $DELAY seconds..."
+  sleep $DELAY
+  ((ATTEMPT++))
 done
-
-echo "🚫 Failed to initiate replica set after $MAX_RETRIES attempts."
-exit 1
-
 
 # Construct the HOST string rs0/mongo1,mongo2... based on the number of replicas
 HOST="rs0/"

--- a/infrastructure/mongodb/on-deploy.sh
+++ b/infrastructure/mongodb/on-deploy.sh
@@ -33,7 +33,10 @@ for (( i=1; i<=REPLICAS; i++ )); do
   fi
   WAIT_HOSTS="${WAIT_HOSTS}mongo${i}:27017"
 done
-
+export WAIT_HOSTS
+export WAIT_AFTER=30
+echo "Waiting for MongoDB replicas: $WAIT_HOSTS"
+/wait
 
 mongo_credentials() {
   if [ ! -z ${MONGODB_ADMIN_USER+x} ] || [ ! -z ${MONGODB_ADMIN_PASSWORD+x} ]; then
@@ -57,7 +60,28 @@ done
 MEMBERS="${MEMBERS}]"
 
 # Initiate the replica set
-mongo $(mongo_credentials) --host mongo1 --eval "rs.initiate({_id:\"rs0\",members:${MEMBERS}})"
+
+MAX_RETRIES=12
+DELAY=10  # seconds
+ATTEMPT=1
+
+# Initiate the replica set
+while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
+    echo "🔄 Attempt $ATTEMPT to initiate replica set..."
+    
+    if mongo $(mongo_credentials) --host mongo1 --eval "rs.initiate({_id:\"rs0\",members:${MEMBERS}})"; then
+        echo "✅ Replica set initiated successfully."
+        break
+    fi
+
+    echo "⏳ Failed to initiate replica set. Retrying in $DELAY seconds..."
+    sleep $DELAY
+    ((ATTEMPT++))
+done
+
+echo "🚫 Failed to initiate replica set after $MAX_RETRIES attempts."
+exit 1
+
 
 # Construct the HOST string rs0/mongo1,mongo2... based on the number of replicas
 HOST="rs0/"

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
## Description

`wait` command is widely used within OpenCRVS project to track service startup.

For mongo-on-update container `wait` command is installed at container startup, but never executed, log example from existing container on e2e environment:
```
....
#######
# Curl command installation
#######
Get:18 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [55.2 kB]
--
Setting up curl (7.68.0-1ubuntu2.25) ...
Get:19 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [28.6 kB]
Processing triggers for libc-bin (2.31-0ubuntu9.15) ...
Reading package lists...
W: GPG error: http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 InRelease: The following signatures were invalid: EXPKEYSIG 656408E390CFB1F5 MongoDB 4.4 Release Signing Key <packaging@mongodb.com>
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
E: The repository 'http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 InRelease' is not signed.
Reading package lists...
Dload  Upload   Total   Spent    Left  Speed
Building dependency tree...
Reading state information...
--:--:-- --:--:--     0
The following additional packages will be installed:
libcurl4
The following NEW packages will be installed:
curl
The following packages will be upgraded:
libcurl4
--:--:-- --:--:--  547k
1 upgraded, 1 newly installed, 0 to remove and 22 not upgraded.
Need to get 396 kB of archives.

#######
# Calling: mongo $(mongo_credentials) --host mongo1 --eval "rs.initiate({_id:\"rs0\",members:${MEMBERS}})"
#######

DATABASE_PREFIX is set to 'ocvs-8448'
MongoDB shell version v4.4.29
connecting to: mongodb://mongo1:27017/?authSource=admin&compressors=disabled&gssapiServiceName=mongodb
Implicit session: session { "id" : UUID("8590531d-00a2-4bc7-8894-ba2af138c0a2") }
MongoDB server version: 4.4.29
{
"operationTime" : Timestamp(1748413124, 1),
"ok" : 0,

```
# Why mongo-on-update is working properly in most cases?

At the beginning of startup script we have call `apt-get update ...`, running these commands adds some extra-time for mongodb to start.


# Goals

Goal of this PR is to add call for `wait` command and add re-try command to `mongo $(mongo_credentials) --host mongo1 --eval "rs.initiate({_id:\"rs0\",members:${MEMBERS}})"`

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable): n/a. This is internal change
- [ ] I have updated the GitHub issue status accordingly: n/a,


`wait` command output from docker container by https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15299994882/job/43040107376 on https://vocrvs-9393-one-workflow.opencrvs.dev/:

> NOTE: vocrvs-9393-one-workflow is result of substitution branch name into pattern `v${release}`. For workflows started from release branch, url would be like https://vX-Y-Z.opencrvs.dev

```
Fetched 396 kB in 1s (577 kB/s)
--
(Reading database ...
Preparing to unpack .../libcurl4_7.68.0-1ubuntu2.25_amd64.deb ...
Unpacking libcurl4:amd64 (7.68.0-1ubuntu2.25) over (7.68.0-1ubuntu2.22) ...
Selecting previously unselected package curl.
Preparing to unpack .../curl_7.68.0-1ubuntu2.25_amd64.deb ...
Unpacking curl (7.68.0-1ubuntu2.25) ...
Setting up libcurl4:amd64 (7.68.0-1ubuntu2.25) ...
Setting up curl (7.68.0-1ubuntu2.25) ...
Processing triggers for libc-bin (2.31-0ubuntu9.15) ...
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
Dload  Upload   Total   Spent    Left  Speed
 
 
Waiting for MongoDB replicas: mongo1:27017
[INFO  wait] --------------------------------------------------------
[INFO  wait]  docker-compose-wait 2.9.0
[INFO  wait] ---------------------------
[DEBUG wait] Starting with configuration:
[DEBUG wait]  - Hosts to be waiting for: [mongo1:27017]
[DEBUG wait]  - Paths to be waiting for: []
[DEBUG wait]  - Timeout before failure: 30 seconds
[DEBUG wait]  - TCP connection timeout before retry: 5 seconds
[DEBUG wait]  - Sleeping time before checking for hosts/paths availability: 0 seconds
[DEBUG wait]  - Sleeping time once all hosts/paths are available: 30 seconds
[DEBUG wait]  - Sleeping time between retries: 1 seconds
[DEBUG wait] --------------------------------------------------------
[INFO  wait] Checking availability of host [mongo1:27017]
[INFO  wait] Host [mongo1:27017] is now available!
[INFO  wait] --------------------------------------------------------
[INFO  wait] Waiting 30 seconds after hosts/paths availability
[INFO  wait] --------------------------------------------------------
🔄 Attempt 1 to initiate replica set...
[INFO  wait] docker-compose-wait - Everything's fine, the application can now start!
[INFO  wait] --------------------------------------------------------
MongoDB shell version v4.4.29
connecting to: mongodb://mongo1:27017/?authSource=admin&compressors=disabled&gssapiServiceName=mongodb
Error: Authentication failed. :
connect@src/mongo/shell/mongo.js:374:17
@(connect):2:6
exception: connect failed
exiting with code 1
⏳ Failed to initiate replica set. Retrying in 10 seconds...
...
⏳ Failed to initiate replica set. Retrying in 10 seconds...
🔄 Attempt 7 to initiate replica set...
MongoDB shell version v4.4.29
connecting to: mongodb://mongo1:27017/?authSource=admin&compressors=disabled&gssapiServiceName=mongodb
Implicit session: session { "id" : UUID("e29e9673-0bd2-4912-bb1d-21e627b110b8") }
MongoDB server version: 4.4.29
{ "ok" : 1 }
✅ Replica set initiated successfully.
config user not found
MongoDB shell version v4.4.29
connecting to: mongodb://mongo1:27017/?authSource=admin&compressors=disabled&gssapiServiceName=mongodb&replicaSet=rs0
Implicit session: session { "id" : UUID("03cfc0ca-da99-4f42-ae8c-c2a239d2d35f") }
MongoDB server version: 4.4.29
switched to db application-config
Successfully added user: {
"user" : "config",
"roles" : [
{
"role" : "readWrite",
"db" : "application-config"
}
]
}
bye
```