### PR TITLE
fix: drop github.event.inputs

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -99,6 +99,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
           path: './${{ github.event.repository.name }}'
 
       - name: Insert production encryption key to environment variables


### PR DESCRIPTION
## Description

Reference documentation:
- Why this change is needed?: https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/
- How inputs are defined?: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#providing-inputs
- How inputs are passed?: https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#inputs-context
- 

## Checklist

- [ ] I have linked the correct Github issue under "Development": n/a
- [x] I have tested the changes locally, and written appropriate tests: Example of environment name passed in run-name:
       ![image](https://github.com/user-attachments/assets/848876d2-7962-4946-97ff-18912cdafb8e)

- [x] I have tested beyond the happy path (e.g. edge cases, failure paths):
       - Manual call: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15301906037
       - Call as reusable workflow: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15299994882/job/43039458211
- [ ] I have updated the changelog with this change (if applicable): n/a
- [ ] I have updated the GitHub issue status accordingly: n/a
