### PR TITLE
Creating draft release from workflow and deleting tag afterwards

### DIFF
--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -98,3 +98,24 @@ jobs:
           git add CHANGELOG.md
           git commit -m "docs: update changelog for ${{ inputs.version }} release candidate"
           git push origin "release/${{ inputs.version }}"
+
+      - name: Create a draft release
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          TAG_NAME="v${{ inputs.version }}"
+          TITLE="OpenCRVS - $TAG_NAME"
+          NOTES="Release notes for version ${{ inputs.version }}"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+          gh release create "$TAG_NAME" \
+            --title "$TITLE" \
+            --notes "$NOTES" \
+            --draft 
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Delete the tag
+        run: | 
+          TAG_NAME="v${{ inputs.version }}"
+          git tag -d "$TAG_NAME"
+          git push origin ":refs/tags/$TAG_NAME"


### PR DESCRIPTION
## Description

This change enables the creation of a draft release through the init-release.yml workflow.
Once the draft release is created, the associated Git tag will be deleted automatically.

## Checklist
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)

