### PR TITLE
fix: Node based images are using "/bin/sh" as shabang

### DIFF
--- a/start-prod.sh
+++ b/start-prod.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
## Description

Example of failed pipeline: https://github.com/opencrvs/opencrvs-countryconfig/commit/cbd7a9957eb013bebf027813ae2895a4a6239ff7

Root cause:
Node based images are using "/bin/sh" as shabang

`/bin/bash` doesn't exist, as a result container countryconfig doesn't start and fails with error:
```
/usr/src/app # ./start-prod.sh 
sh: ./start-prod.sh: not found
```

To fix the issue we need to drop shabang string or redifine with correct shell:
```
#!/bin/sh
```


## Checklist

- [ ] I have linked the correct Github issue under "Development": n/a
- [ ] I have tested the changes locally, and written appropriate tests:
       ```
        /usr/src/app # ./start-prod.sh 
        yarn run v1.22.22
        $ ts-node --transpile-only -r tsconfig-paths/register src/index.ts
       ...
      ```
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths): n/a
- [ ] I have updated the changelog with this change (if applicable): n/a
- [ ] I have updated the GitHub issue status accordingly: n/a
