### PR TITLE
fix: Add checkout depth to fix default behaviour of github action

### DIFF
--- a/.github/workflows/clear-environment.yml
+++ b/.github/workflows/clear-environment.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   reset-data:
     name: 'Reset data'
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
     outputs:
       outcome: ${{ steps.reset-data.outcome }}
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
           path: './${{ github.event.repository.name }}'
 
       - name: Read known hosts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ on:
         default: false
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
     outputs:
       outcome: ${{ steps.deploy.outcome }}
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
           path: './${{ github.event.repository.name }}'
 
       - name: Checkout country branch


### PR DESCRIPTION
## Description

`actions/checkout@v4` checks out the code in a detached HEAD state and uses a shallow clone by default, which means:
- Git does not track branches in the usual way (HEAD isn't on main, release/..., etc.).
- Only a limited portion of the history is fetched (usually just the last commit).
- Commits made and pushed in one job do not persist to another job unless explicitly handled.
- Always use fetch-depth: 0 if you're manipulating history or pushing.
- Use ref: ${{ github.ref_name }} to ensure you're working on the actual branch.

Proof example: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15258087389/job/42910430821

`farajaland-tmp1` was successfully created on Hetzner:
[create-server / Create New HCloud Environment](https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15258087389/job/42910344838#logs)
Server was provisioned with IP 138.199.236.19:
![image](https://github.com/user-attachments/assets/34a47eab-c7eb-4f06-94fe-dd72b1742651)
Changes commited with hash `f8bf630`
![image](https://github.com/user-attachments/assets/98142d5b-8476-4f3e-862b-e074ad3f8930)

`farajaland-tmp1` provision failed due error: [provision-server / Provision tmp1](https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15258087389/job/42910430821#logs)
```
TASK [Gathering Facts] *********************************************************
fatal: [farajaland-tmp1]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: OpenSSH_9.6p1 Ubuntu-3ubuntu13.11, OpenSSL 3.0.13 30 Jan 2024\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 19: include /etc/ssh/ssh_config.d/*.conf matched no files\r\ndebug1: /etc/ssh/ssh_config line 21: Applying options for *\r\ndebug1: auto-mux: Trying existing master at '/home/runner/.ansible/cp/106e022307'\r\ndebug1: Control socket \"/home/runner/.ansible/cp/106e022307\" does not exist\r\ndebug1: Connecting to 188.245.88.47 [188.245.88.47] port 22.\r\ndebug1: connect to address 188.245.88.47 port 22: Connection timed out\r\nssh: connect to host 188.245.88.47 port 22: Connection timed out", "unreachable": true}
```
Taking closer look into logs shows that previous commit (`ae1b2da33241ed0f36b29823c71f568a1346c022`) was pulled instead of latest:
![image](https://github.com/user-attachments/assets/b26600fb-b1aa-49df-ad02-4ea30f146d52)

IP address 188.245.88.47 also doesn't match latest 138.199.236.19

Moving back to previous step 

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
