### PR TITLE
Country config syntax tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/toolkit": "1.8.0-rc.be568cf",
+    "@opencrvs/toolkit": "1.8.0-rc.3740352",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",
     "@types/fhir": "^0.0.30",

--- a/src/form/v2/birth/forms/pages/father.ts
+++ b/src/form/v2/birth/forms/pages/father.ts
@@ -31,7 +31,6 @@ import {
   IdType,
   idTypeOptions,
   maritalStatusOptions,
-  PersonType,
   yesNoRadioOptions,
   YesNoTypes
 } from '../../../person'
@@ -42,7 +41,7 @@ export const requireFatherDetails = or(
 )
 
 export const father = defineFormPage({
-  id: PersonType.father,
+  id: 'father',
   title: {
     defaultMessage: "Father's details",
     description: 'Form section title for fathers details',
@@ -50,12 +49,12 @@ export const father = defineFormPage({
   },
   fields: [
     {
-      id: `${PersonType.father}.detailsNotAvailable`,
+      id: 'father.detailsNotAvailable',
       type: FieldType.CHECKBOX,
       label: {
         defaultMessage: "Father's details are not available",
         description: 'This is the label for the field',
-        id: `event.birth.action.declare.form.section.father.field.detailsNotAvailable.label`
+        id: 'event.birth.action.declare.form.section.father.field.detailsNotAvailable.label'
       },
       conditionals: [
         {
@@ -67,7 +66,7 @@ export const father = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.father}.details.divider`,
+      id: 'father.details.divider',
       type: FieldType.DIVIDER,
       label: emptyMessage,
       conditionals: [
@@ -80,7 +79,7 @@ export const father = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.father}.reason`,
+      id: 'father.reason',
       type: FieldType.TEXT,
       required: true,
       label: {
@@ -99,14 +98,14 @@ export const father = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.father}.firstname`,
+      id: 'father.firstname',
       configuration: { maxLength: MAX_NAME_LENGTH },
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'First name(s)',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.firstname.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.firstname.label'
       },
       conditionals: [
         {
@@ -114,17 +113,17 @@ export const father = defineFormPage({
           conditional: requireFatherDetails
         }
       ],
-      validation: [invalidNameValidator(`${PersonType.father}.firstname`)]
+      validation: [invalidNameValidator('father.firstname')]
     },
     {
-      id: `${PersonType.father}.surname`,
+      id: 'father.surname',
       configuration: { maxLength: MAX_NAME_LENGTH },
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'Last name',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.surname.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.surname.label'
       },
       conditionals: [
         {
@@ -132,7 +131,7 @@ export const father = defineFormPage({
           conditional: requireFatherDetails
         }
       ],
-      validation: [invalidNameValidator(`${PersonType.father}.surname`)]
+      validation: [invalidNameValidator('father.surname')]
     },
     {
       id: 'father.dob',
@@ -143,7 +142,7 @@ export const father = defineFormPage({
           message: {
             defaultMessage: 'Must be a valid Birthdate',
             description: 'This is the error message for invalid date',
-            id: `v2.event.birth.action.declare.form.section.person.field.dob.error`
+            id: 'v2.event.birth.action.declare.form.section.person.field.dob.error'
           },
           validator: field('father.dob').isBefore().now()
         },
@@ -151,8 +150,8 @@ export const father = defineFormPage({
           message: {
             defaultMessage: "Birth date must be before child's birth date",
             description:
-              'This is the error message for a birth date after child`s birth date',
-            id: `v2.event.birth.action.declare.form.section.person.dob.afterChild`
+              "This is the error message for a birth date after child's birth date",
+            id: 'v2.event.birth.action.declare.form.section.person.dob.afterChild'
           },
           validator: field('father.dob').isBefore().date(field('child.dob'))
         }
@@ -160,25 +159,25 @@ export const father = defineFormPage({
       label: {
         defaultMessage: 'Date of birth',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.dob.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.dob.label'
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            not(field(`${PersonType.father}.dobUnknown`).isEqualTo(true)),
+            not(field('father.dobUnknown').isEqualTo(true)),
             requireFatherDetails
           )
         }
       ]
     },
     {
-      id: `${PersonType.father}.dobUnknown`,
+      id: 'father.dobUnknown',
       type: FieldType.CHECKBOX,
       label: {
         defaultMessage: 'Exact date of birth unknown',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.age.checkbox.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.age.checkbox.label'
       },
       conditionals: [
         {
@@ -192,11 +191,11 @@ export const father = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.father}.age`,
+      id: 'father.age',
       type: FieldType.TEXT,
       required: true,
       label: {
-        defaultMessage: `Age of father`,
+        defaultMessage: 'Age of father',
         description: 'This is the label for the field',
         id: 'v2.event.birth.action.declare.form.section.father.field.age.label'
       },
@@ -204,27 +203,27 @@ export const father = defineFormPage({
         postfix: {
           defaultMessage: 'years',
           description: 'This is the postfix for age field',
-          id: `v2.event.birth.action.declare.form.section.person.field.age.postfix`
+          id: 'v2.event.birth.action.declare.form.section.person.field.age.postfix'
         }
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.father}.dobUnknown`).isEqualTo(true),
+            field('father.dobUnknown').isEqualTo(true),
             requireFatherDetails
           )
         }
       ]
     },
     {
-      id: `${PersonType.father}.nationality`,
+      id: 'father.nationality',
       type: FieldType.COUNTRY,
       required: true,
       label: {
         defaultMessage: 'Nationality',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.nationality.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.nationality.label'
       },
       conditionals: [
         {
@@ -235,13 +234,13 @@ export const father = defineFormPage({
       defaultValue: 'FAR'
     },
     {
-      id: `${PersonType.father}.idType`,
+      id: 'father.idType',
       type: FieldType.SELECT,
       required: true,
       label: {
         defaultMessage: 'Type of ID',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.idType.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.idType.label'
       },
       options: idTypeOptions,
       conditionals: [
@@ -264,7 +263,7 @@ export const father = defineFormPage({
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.father}.idType`).isEqualTo(IdType.NATIONAL_ID),
+            field('father.idType').isEqualTo(IdType.NATIONAL_ID),
             requireFatherDetails
           )
         }
@@ -285,47 +284,45 @@ export const father = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.father}.passport`,
+      id: 'father.passport',
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'ID Number',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.passport.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.passport.label'
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.father}.idType`).isEqualTo(IdType.PASSPORT),
+            field('father.idType').isEqualTo(IdType.PASSPORT),
             requireFatherDetails
           )
         }
       ]
     },
     {
-      id: `${PersonType.father}.brn`,
+      id: 'father.brn',
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'ID Number',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.brn.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.brn.label'
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.father}.idType`).isEqualTo(
-              IdType.BIRTH_REGISTRATION_NUMBER
-            ),
+            field('father.idType').isEqualTo(IdType.BIRTH_REGISTRATION_NUMBER),
             requireFatherDetails
           )
         }
       ]
     },
     {
-      id: `${PersonType.father}.addressDivider`,
+      id: 'father.addressDivider',
       type: FieldType.DIVIDER,
       label: emptyMessage,
       conditionals: [
@@ -336,12 +333,12 @@ export const father = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.father}.addressHelper`,
+      id: 'father.addressHelper',
       type: FieldType.PARAGRAPH,
       label: {
         defaultMessage: 'Usual place of residence',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.addressHelper.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.addressHelper.label'
       },
       configuration: { styles: { fontVariant: 'h3' } },
       conditionals: [
@@ -359,7 +356,7 @@ export const father = defineFormPage({
       label: {
         defaultMessage: "Same as mother's usual place of residence?",
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.father.field.address.addressSameAs.label`
+        id: 'v2.event.birth.action.declare.form.section.father.field.address.addressSameAs.label'
       },
       defaultValue: YesNoTypes.YES,
       conditionals: [
@@ -406,7 +403,7 @@ export const father = defineFormPage({
       }
     },
     {
-      id: `${PersonType.father}.addressDivider_2`,
+      id: 'father.addressDivider_2',
       type: FieldType.DIVIDER,
       label: emptyMessage,
       conditionals: [
@@ -417,13 +414,13 @@ export const father = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.father}.maritalStatus`,
+      id: 'father.maritalStatus',
       type: FieldType.SELECT,
       required: false,
       label: {
         defaultMessage: 'Marital Status',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.maritalStatus.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.maritalStatus.label'
       },
       options: maritalStatusOptions,
       conditionals: [
@@ -434,13 +431,13 @@ export const father = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.father}.educationalAttainment`,
+      id: 'father.educationalAttainment',
       type: FieldType.SELECT,
       required: false,
       label: {
         defaultMessage: 'Level of education',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.educationalAttainment.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.educationalAttainment.label'
       },
       options: educationalAttainmentOptions,
       conditionals: [
@@ -451,13 +448,13 @@ export const father = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.father}.occupation`,
+      id: 'father.occupation',
       type: FieldType.TEXT,
       required: false,
       label: {
         defaultMessage: 'Occupation',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.occupation.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.occupation.label'
       },
       conditionals: [
         {

--- a/src/form/v2/birth/forms/pages/informant.ts
+++ b/src/form/v2/birth/forms/pages/informant.ts
@@ -26,7 +26,7 @@ import {
   MAX_NAME_LENGTH,
   nationalIdValidator
 } from '@countryconfig/form/v2/birth/validators'
-import { IdType, idTypeOptions, PersonType } from '../../../person'
+import { IdType, idTypeOptions } from '../../../person'
 
 export const InformantType = {
   MOTHER: 'MOTHER',
@@ -100,7 +100,7 @@ export const informantOtherThanParent = and(
 )
 
 export const informant = defineFormPage({
-  id: PersonType.informant,
+  id: 'informant',
   title: {
     defaultMessage: "Informant's details",
     description: 'Form section title for informants details',
@@ -108,7 +108,7 @@ export const informant = defineFormPage({
   },
   fields: [
     {
-      id: `${PersonType.informant}.relation`,
+      id: 'informant.relation',
       type: FieldType.SELECT,
       required: true,
       label: {
@@ -119,7 +119,7 @@ export const informant = defineFormPage({
       options: birthInformantTypeOptions
     },
     {
-      id: `${PersonType.informant}.other.relation`,
+      id: 'informant.other.relation',
       type: FieldType.TEXT,
       required: true,
       label: {
@@ -138,14 +138,14 @@ export const informant = defineFormPage({
       parent: field('informant.relation')
     },
     {
-      id: `${PersonType.informant}.firstname`,
+      id: 'informant.firstname',
       configuration: { maxLength: MAX_NAME_LENGTH },
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'First name(s)',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.firstname.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.firstname.label'
       },
       conditionals: [
         {
@@ -156,14 +156,14 @@ export const informant = defineFormPage({
       parent: field('informant.relation')
     },
     {
-      id: `${PersonType.informant}.surname`,
+      id: 'informant.surname',
       configuration: { maxLength: MAX_NAME_LENGTH },
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'Last name',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.surname.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.surname.label'
       },
       conditionals: [
         {
@@ -182,7 +182,7 @@ export const informant = defineFormPage({
           message: {
             defaultMessage: 'Must be a valid Birthdate',
             description: 'This is the error message for invalid date',
-            id: `v2.event.birth.action.declare.form.section.person.field.dob.error`
+            id: 'v2.event.birth.action.declare.form.section.person.field.dob.error'
           },
           validator: field('informant.dob').isBefore().now()
         },
@@ -190,8 +190,8 @@ export const informant = defineFormPage({
           message: {
             defaultMessage: "Birth date must be before child's birth date",
             description:
-              'This is the error message for a birth date after child`s birth date',
-            id: `v2.event.birth.action.declare.form.section.person.dob.afterChild`
+              "This is the error message for a birth date after child's birth date",
+            id: 'v2.event.birth.action.declare.form.section.person.dob.afterChild'
           },
           validator: field('informant.dob').isBefore().date(field('child.dob'))
         }
@@ -199,13 +199,13 @@ export const informant = defineFormPage({
       label: {
         defaultMessage: 'Date of birth',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.dob.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.dob.label'
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            not(field(`${PersonType.informant}.dobUnknown`).isEqualTo(true)),
+            not(field('informant.dobUnknown').isEqualTo(true)),
             informantOtherThanParent
           )
         }
@@ -213,12 +213,12 @@ export const informant = defineFormPage({
       parent: field('informant.relation')
     },
     {
-      id: `${PersonType.informant}.dobUnknown`,
+      id: 'informant.dobUnknown',
       type: FieldType.CHECKBOX,
       label: {
         defaultMessage: 'Exact date of birth unknown',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.age.checkbox.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.age.checkbox.label'
       },
       conditionals: [
         {
@@ -233,7 +233,7 @@ export const informant = defineFormPage({
       parent: field('informant.relation')
     },
     {
-      id: `${PersonType.informant}.age`,
+      id: 'informant.age',
       type: FieldType.TEXT,
       required: true,
       label: {
@@ -245,14 +245,14 @@ export const informant = defineFormPage({
         postfix: {
           defaultMessage: 'years',
           description: 'This is the postfix for age field',
-          id: `v2.event.birth.action.declare.form.section.person.field.age.postfix`
+          id: 'v2.event.birth.action.declare.form.section.person.field.age.postfix'
         }
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.informant}.dobUnknown`).isEqualTo(true),
+            field('informant.dobUnknown').isEqualTo(true),
             informantOtherThanParent
           )
         }
@@ -260,13 +260,13 @@ export const informant = defineFormPage({
       parent: field('informant.relation')
     },
     {
-      id: `${PersonType.informant}.nationality`,
+      id: 'informant.nationality',
       type: FieldType.COUNTRY,
       required: true,
       label: {
         defaultMessage: 'Nationality',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.nationality.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.nationality.label'
       },
       conditionals: [
         {
@@ -278,13 +278,13 @@ export const informant = defineFormPage({
       parent: field('informant.relation')
     },
     {
-      id: `${PersonType.informant}.idType`,
+      id: 'informant.idType',
       type: FieldType.SELECT,
       required: true,
       label: {
         defaultMessage: 'Type of ID',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.idType.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.idType.label'
       },
       options: idTypeOptions,
       conditionals: [
@@ -330,19 +330,19 @@ export const informant = defineFormPage({
       parent: field('informant.relation')
     },
     {
-      id: `${PersonType.informant}.passport`,
+      id: 'informant.passport',
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'ID Number',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.passport.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.passport.label'
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.informant}.idType`).isEqualTo(IdType.PASSPORT),
+            field('informant.idType').isEqualTo(IdType.PASSPORT),
             informantOtherThanParent
           )
         }
@@ -350,19 +350,19 @@ export const informant = defineFormPage({
       parent: field('informant.relation')
     },
     {
-      id: `${PersonType.informant}.brn`,
+      id: 'informant.brn',
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'ID Number',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.brn.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.brn.label'
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.informant}.idType`).isEqualTo(
+            field('informant.idType').isEqualTo(
               IdType.BIRTH_REGISTRATION_NUMBER
             ),
             informantOtherThanParent
@@ -372,7 +372,7 @@ export const informant = defineFormPage({
       parent: field('informant.relation')
     },
     {
-      id: `${PersonType.informant}.addressDivider_1`,
+      id: 'informant.addressDivider_1',
       type: FieldType.DIVIDER,
       label: emptyMessage,
       conditionals: [
@@ -384,12 +384,12 @@ export const informant = defineFormPage({
       parent: field('informant.relation')
     },
     {
-      id: `${PersonType.informant}.addressHelper`,
+      id: 'informant.addressHelper',
       type: FieldType.PARAGRAPH,
       label: {
         defaultMessage: 'Usual place of residence',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.addressHelper.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.addressHelper.label'
       },
       configuration: { styles: { fontVariant: 'h3' } },
       conditionals: [

--- a/src/form/v2/birth/forms/pages/mother.ts
+++ b/src/form/v2/birth/forms/pages/mother.ts
@@ -26,14 +26,14 @@ import {
   MAX_NAME_LENGTH
 } from '@countryconfig/form/v2/birth/validators'
 import { InformantType } from './informant'
-import { IdType, idTypeOptions, PersonType } from '../../../person'
+import { IdType, idTypeOptions } from '../../../person'
 import {
   educationalAttainmentOptions,
   maritalStatusOptions
 } from '../../../../common/select-options'
 
 export const requireMotherDetails = or(
-  field(`${PersonType.mother}.detailsNotAvailable`).isFalsy(),
+  field('mother.detailsNotAvailable').isFalsy(),
   field('informant.relation').isEqualTo(InformantType.MOTHER)
 )
 
@@ -47,12 +47,12 @@ export const mother = defineFormPage({
   },
   fields: [
     {
-      id: `${PersonType.mother}.detailsNotAvailable`,
+      id: 'mother.detailsNotAvailable',
       type: FieldType.CHECKBOX,
       label: {
         defaultMessage: "Mother's details are not available",
         description: 'This is the label for the field',
-        id: `event.birth.action.declare.form.section.mother.field.detailsNotAvailable.label`
+        id: 'event.birth.action.declare.form.section.mother.field.detailsNotAvailable.label'
       },
       conditionals: [
         {
@@ -64,7 +64,7 @@ export const mother = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.mother}.details.divider`,
+      id: 'mother.details.divider',
       type: FieldType.DIVIDER,
       label: emptyMessage,
       conditionals: [
@@ -77,7 +77,7 @@ export const mother = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.mother}.reason`,
+      id: 'mother.reason',
       type: FieldType.TEXT,
       required: true,
       label: {
@@ -89,21 +89,21 @@ export const mother = defineFormPage({
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.mother}.detailsNotAvailable`).isEqualTo(true),
+            field('mother.detailsNotAvailable').isEqualTo(true),
             not(field('informant.relation').isEqualTo(InformantType.MOTHER))
           )
         }
       ]
     },
     {
-      id: `${PersonType.mother}.firstname`,
+      id: 'mother.firstname',
       configuration: { maxLength: MAX_NAME_LENGTH },
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'First name(s)',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.firstname.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.firstname.label'
       },
       conditionals: [
         {
@@ -111,17 +111,17 @@ export const mother = defineFormPage({
           conditional: requireMotherDetails
         }
       ],
-      validation: [invalidNameValidator(`${PersonType.mother}.firstname`)]
+      validation: [invalidNameValidator('mother.firstname')]
     },
     {
-      id: `${PersonType.mother}.surname`,
+      id: 'mother.surname',
       configuration: { maxLength: MAX_NAME_LENGTH },
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'Last name',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.surname.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.surname.label'
       },
       conditionals: [
         {
@@ -129,10 +129,10 @@ export const mother = defineFormPage({
           conditional: requireMotherDetails
         }
       ],
-      validation: [invalidNameValidator(`${PersonType.mother}.surname`)]
+      validation: [invalidNameValidator('mother.surname')]
     },
     {
-      id: `${PersonType.mother}.dob`,
+      id: 'mother.dob',
       type: 'DATE',
       required: true,
       validation: [
@@ -140,7 +140,7 @@ export const mother = defineFormPage({
           message: {
             defaultMessage: 'Must be a valid birth date',
             description: 'This is the error message for invalid date',
-            id: `v2.event.birth.action.declare.form.section.person.field.dob.error`
+            id: 'v2.event.birth.action.declare.form.section.person.field.dob.error'
           },
           validator: field('mother.dob').isBefore().now()
         },
@@ -148,8 +148,8 @@ export const mother = defineFormPage({
           message: {
             defaultMessage: "Birth date must be before child's birth date",
             description:
-              'This is the error message for a birth date after child`s birth date',
-            id: `v2.event.birth.action.declare.form.section.person.dob.afterChild`
+              "This is the error message for a birth date after child's birth date",
+            id: 'v2.event.birth.action.declare.form.section.person.dob.afterChild'
           },
           validator: field('mother.dob').isBefore().date(field('child.dob'))
         }
@@ -157,25 +157,25 @@ export const mother = defineFormPage({
       label: {
         defaultMessage: 'Date of birth',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.dob.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.dob.label'
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            not(field(`${PersonType.mother}.dobUnknown`).isEqualTo(true)),
+            not(field('mother.dobUnknown').isEqualTo(true)),
             requireMotherDetails
           )
         }
       ]
     },
     {
-      id: `${PersonType.mother}.dobUnknown`,
+      id: 'mother.dobUnknown',
       type: FieldType.CHECKBOX,
       label: {
         defaultMessage: 'Exact date of birth unknown',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.age.checkbox.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.age.checkbox.label'
       },
       conditionals: [
         {
@@ -189,11 +189,11 @@ export const mother = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.mother}.age`,
+      id: 'mother.age',
       type: FieldType.TEXT,
       required: true,
       label: {
-        defaultMessage: `Age of mother`,
+        defaultMessage: 'Age of mother',
         description: 'This is the label for the field',
         id: 'v2.event.birth.action.declare.form.section.mother.field.age.label'
       },
@@ -201,27 +201,27 @@ export const mother = defineFormPage({
         postfix: {
           defaultMessage: 'years',
           description: 'This is the postfix for age field',
-          id: `v2.event.birth.action.declare.form.section.person.field.age.postfix`
+          id: 'v2.event.birth.action.declare.form.section.person.field.age.postfix'
         }
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.mother}.dobUnknown`).isEqualTo(true),
+            field('mother.dobUnknown').isEqualTo(true),
             requireMotherDetails
           )
         }
       ]
     },
     {
-      id: `${PersonType.mother}.nationality`,
+      id: 'mother.nationality',
       type: FieldType.COUNTRY,
       required: true,
       label: {
         defaultMessage: 'Nationality',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.nationality.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.nationality.label'
       },
       conditionals: [
         {
@@ -232,13 +232,13 @@ export const mother = defineFormPage({
       defaultValue: 'FAR'
     },
     {
-      id: `${PersonType.mother}.idType`,
+      id: 'mother.idType',
       type: FieldType.SELECT,
       required: true,
       label: {
         defaultMessage: 'Type of ID',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.idType.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.idType.label'
       },
       options: idTypeOptions,
       conditionals: [
@@ -255,7 +255,7 @@ export const mother = defineFormPage({
       label: {
         defaultMessage: 'ID Number',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.nid.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.nid.label'
       },
       conditionals: [
         {
@@ -282,47 +282,45 @@ export const mother = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.mother}.passport`,
+      id: 'mother.passport',
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'ID Number',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.passport.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.passport.label'
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.mother}.idType`).isEqualTo(IdType.PASSPORT),
+            field('mother.idType').isEqualTo(IdType.PASSPORT),
             requireMotherDetails
           )
         }
       ]
     },
     {
-      id: `${PersonType.mother}.brn`,
+      id: 'mother.brn',
       type: FieldType.TEXT,
       required: true,
       label: {
         defaultMessage: 'ID Number',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.brn.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.brn.label'
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: and(
-            field(`${PersonType.mother}.idType`).isEqualTo(
-              IdType.BIRTH_REGISTRATION_NUMBER
-            ),
+            field('mother.idType').isEqualTo(IdType.BIRTH_REGISTRATION_NUMBER),
             requireMotherDetails
           )
         }
       ]
     },
     {
-      id: `${PersonType.mother}.addressDivider_1`,
+      id: 'mother.addressDivider_1',
       type: FieldType.DIVIDER,
       label: emptyMessage,
       conditionals: [
@@ -333,12 +331,12 @@ export const mother = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.mother}.addressHelper`,
+      id: 'mother.addressHelper',
       type: FieldType.PARAGRAPH,
       label: {
         defaultMessage: 'Usual place of residence',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.addressHelper.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.addressHelper.label'
       },
       configuration: { styles: { fontVariant: 'h3' } },
       conditionals: [
@@ -349,7 +347,7 @@ export const mother = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.mother}.address`,
+      id: 'mother.address',
       type: FieldType.ADDRESS,
       hideLabel: true,
       label: {
@@ -372,7 +370,7 @@ export const mother = defineFormPage({
       }
     },
     {
-      id: `${PersonType.mother}.addressDivider_2`,
+      id: 'mother.addressDivider_2',
       type: FieldType.DIVIDER,
       label: emptyMessage,
       conditionals: [
@@ -383,13 +381,13 @@ export const mother = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.mother}.maritalStatus`,
+      id: 'mother.maritalStatus',
       type: FieldType.SELECT,
       required: false,
       label: {
         defaultMessage: 'Marital Status',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.maritalStatus.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.maritalStatus.label'
       },
       options: maritalStatusOptions,
       conditionals: [
@@ -400,13 +398,13 @@ export const mother = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.mother}.educationalAttainment`,
+      id: 'mother.educationalAttainment',
       type: FieldType.SELECT,
       required: false,
       label: {
         defaultMessage: 'Level of education',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.educationalAttainment.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.educationalAttainment.label'
       },
       options: educationalAttainmentOptions,
       conditionals: [
@@ -417,13 +415,13 @@ export const mother = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.mother}.occupation`,
+      id: 'mother.occupation',
       type: FieldType.TEXT,
       required: false,
       label: {
         defaultMessage: 'Occupation',
         description: 'This is the label for the field',
-        id: `v2.event.birth.action.declare.form.section.person.field.occupation.label`
+        id: 'v2.event.birth.action.declare.form.section.person.field.occupation.label'
       },
       conditionals: [
         {
@@ -433,7 +431,7 @@ export const mother = defineFormPage({
       ]
     },
     {
-      id: `${PersonType.mother}.previousBirths`,
+      id: 'mother.previousBirths',
       type: FieldType.NUMBER,
       required: false,
       label: {

--- a/src/form/v2/birth/index.ts
+++ b/src/form/v2/birth/index.ts
@@ -31,7 +31,7 @@ export const birthEvent = defineConfig({
     description: 'This is what this event is referred as in the system',
     id: 'v2.event.birth.label'
   },
-  dateOfEvent: field('child.dob').getId(),
+  dateOfEvent: field('child.dob'),
   title: {
     defaultMessage: '{child.firstname} {child.surname}',
     description: 'This is the title of the summary',

--- a/src/form/v2/person/index.ts
+++ b/src/form/v2/person/index.ts
@@ -12,15 +12,6 @@
 import { TranslationConfig } from '@opencrvs/toolkit/events'
 import { createSelectOptions } from '../utils'
 
-export const PersonType = {
-  father: 'father',
-  mother: 'mother',
-  informant: 'informant',
-  applicant: 'applicant'
-} as const
-
-export type PersonType = keyof typeof PersonType
-
 export const IdType = {
   NATIONAL_ID: 'NATIONAL_ID',
   PASSPORT: 'PASSPORT',

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,10 +834,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opencrvs/toolkit@1.8.0-rc.be568cf":
-  version "1.8.0-rc.be568cf"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.8.0-rc.be568cf.tgz#aeff5a0c97bbfcb2093060d94e75b074b0d8d1d4"
-  integrity sha512-AQPZSaFk7TBjWJv30KDjp3VN5fWzW9J/oA/I4BsleEAWWDKdDYy7tCl7UOkRzuI84liFQht8hcmjLXM9ns6cEg==
+"@opencrvs/toolkit@1.8.0-rc.3740352":
+  version "1.8.0-rc.3740352"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.8.0-rc.3740352.tgz#83c7179c9aa36289383f19074119732fa6ee1ff2"
+  integrity sha512-DrJpNoadPHf/ILymT07VcYTT6b/S0gwWiX0m+Zep+WpzhXUjfp1Ddf8CNiCAM3GhsSD2ilAOZQBmBFdLJyLicA==
   dependencies:
     "@trpc/client" "^11.0.0-rc.648"
     "@trpc/server" "^11.0.0-rc.532"
@@ -5069,7 +5069,7 @@ string-argv@^0.0.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
   integrity sha512-p6/Mqq0utTQWUeGMi/m0uBtlLZEwXSY3+mXzeRRqw7fz5ezUb28Wr0R99NlfbWaMmL/jCyT9be4jpn7Yz8IO8w==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5094,15 +5094,6 @@ string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string-width@^4.1.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -5129,7 +5120,7 @@ stringify-object@^3.2.2:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5149,13 +5140,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"


### PR DESCRIPTION
## Description

### Syntactic changes

This pull request removes indirection from the form configuration:
```ts
id: `${PersonType.father}.detailsNotAvailable`
``` 
are simplified to `id: 'father.detailsNotAvailable'` to make searching for fields easier.

### Field API change

```ts
dateOfEvent: field('child.dob').getId(),
```

can now be used just as 

```ts
dateOfEvent: field('child.dob'),
```

This should be the canonical way of referring to a field and serialise to `{$$field: 'child.dob'}`

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
