### PR TITLE
fix: local env broken after reverted current_user to ansible_user to …

### DIFF
--- a/infrastructure/local-development/local.macos.yml
+++ b/infrastructure/local-development/local.macos.yml
@@ -13,15 +13,15 @@ all:
 docker-manager-first:
   hosts:
     manager:
-      ansible_host: 'manager@orb'
-      ansible_user: 'provision@manager'
+      ansible_host: 'manager.orb.local'
+      ansible_user: 'provision'
       data_label: data1
 
 # QA and staging servers are not configured to use workers.
 docker-workers:
   hosts:
     worker:
-      ansible_host: 'worker@orb'
-      ansible_user: 'provision@worker'
+      ansible_host: 'worker.orb.local'
+      ansible_user: 'provision'
       data_label: data2
 

--- a/infrastructure/local-development/provision.ipynb
+++ b/infrastructure/local-development/provision.ipynb
@@ -118,6 +118,7 @@
     "  -e mongodb_admin_password=\"$mongo_pass\" \\\\\n",
     "  -e backup_encryption_passphrase=\"$backup_pass\" \\\\\n",
     "  -e elasticsearch_superuser_password=\"$es_pass\" \\\\\n",
+    "  --private-key ./.ssh/ssh-key\n",
     "  -vv\n",
     "\"\"\""
    ]


### PR DESCRIPTION
## Description

Revert was made here: https://github.com/opencrvs/opencrvs-countryconfig/pull/755

PR aims to fix local environment

`provision` user is used for running ansible on local and server environments.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
