### PR TITLE
fix: Avoid asking questions about updated files

### DIFF
--- a/infrastructure/server-setup/backups.yml
+++ b/infrastructure/server-setup/backups.yml
@@ -203,7 +203,7 @@
         - backups
 
     - name: Copy the test connection file to the backup server
-      shell: rsync --timeout=30 -avz -e "ssh -o StrictHostKeyChecking=no" /tmp/test_connection.txt {{ backup_server_user }}@{{ destination_server }}:{{ backup_server_remote_target_directory }}/test_connection.txt
+      shell: rsync --mkpath --timeout=30 -avz -e "ssh -o StrictHostKeyChecking=no" /tmp/test_connection.txt {{ backup_server_user }}@{{ destination_server }}:{{ backup_server_remote_target_directory }}/test_connection.txt
       remote_user: '{{ crontab_user }}'
       when: "'backups' in groups and groups['backups'] | length > 0 and enable_backups"
       tags:

--- a/infrastructure/server-setup/tasks/users.yml
+++ b/infrastructure/server-setup/tasks/users.yml
@@ -97,10 +97,11 @@
     state: present
 
 - name: Ensure SSH server is installed
-  ansible.builtin.package:
+  ansible.builtin.apt:
     name: openssh-server
     state: present
   become: yes
+  dpkg_options: 'force-confold,force-confdef'
 
 - name: Check short Diffie-Hellman keys
   ansible.builtin.shell: |


### PR DESCRIPTION
## Description

See issue here: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15561736743/job/43815567582

What Do These Options Do?

* `--force-confold`: Keeps the currently installed version of any configuration file (the "old" one).
* `--force-confdef`: If the config file was not changed, automatically installs the new version; otherwise, keeps your changes unless you specify otherwise.


`ansible.builtin.package` doesn't have an option to take non-interactive decision: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html

Provision script was tested multiple time after fix at: https://github.com/opencrvs/opencrvs-farajaland/pull/1452/files

PR also contains a fix for: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15585106472/job/43889489796

Test results are here: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15587006343


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
