### PR TITLE
fix: Change the way of defining node version and replace `cd` commands with `working-directory`

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -46,19 +46,16 @@ jobs:
           path: './${{ github.event.repository.name }}'
 
       - name: Checkout country branch
-        run: |
-          cd ${{ github.event.repository.name }}
-          git checkout ${{ github.event.inputs.countryconfig-image-tag }}
-          cd ../
+        working-directory: ${{ github.event.repository.name }}
+        run: git checkout ${{ github.event.inputs.countryconfig-image-tag }}
 
       - name: Checkout core branch
-        run: |
-          cd opencrvs-core
-          git checkout ${{ github.event.inputs.core-image-tag }}
+        working-directory: opencrvs-core
+        run: git checkout ${{ github.event.inputs.core-image-tag }}
 
       - name: Read known hosts
+        working-directory: ${{ github.event.repository.name }}
         run: |
-          cd ${{ github.event.repository.name }}
           echo "KNOWN_HOSTS<<EOF" >> $GITHUB_ENV
           sed -i -e '$a\' ./infrastructure/known-hosts
           cat ./infrastructure/known-hosts >> $GITHUB_ENV
@@ -96,9 +93,8 @@ jobs:
           done
 
       - name: Export all secrets and environment variables
+        working-directory: ${{ github.event.repository.name }}
         run: |
-          cd ./${{ github.event.repository.name }}
-
           SECRETS_JSON_WITH_NEWLINES=$(cat<<EOF
             ${{ toJSON(secrets) }}
           EOF)
@@ -135,9 +131,14 @@ jobs:
               .[]' <<< "$VARS_JSON_WITH_NEWLINES"
           )
 
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ${{ github.event.repository.name }}/.nvmrc
+
       - name: Deploy to ${{ github.event.inputs.environment }}
+        working-directory: ${{ github.event.repository.name }}
         run: |
-          cd ./${{ github.event.repository.name }}
           yarn deploy \
           --clear_data=no \
           --environment=${{ github.event.inputs.environment }} \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,19 +44,16 @@ jobs:
           path: './${{ github.event.repository.name }}'
 
       - name: Checkout country branch
-        run: |
-          cd ${{ github.event.repository.name }}
-          git checkout ${{ github.event.inputs.countryconfig-image-tag }}
-          cd ../
+        working-directory: ${{ github.event.repository.name }}
+        run: git checkout ${{ github.event.inputs.countryconfig-image-tag }}
 
       - name: Checkout core branch
-        run: |
-          cd opencrvs-core
-          git checkout ${{ github.event.inputs.core-image-tag }}
+        working-directory: opencrvs-core
+        run: git checkout ${{ github.event.inputs.core-image-tag }}
 
       - name: Read known hosts
+        working-directory: ${{ github.event.repository.name }}
         run: |
-          cd ${{ github.event.repository.name }}
           echo "KNOWN_HOSTS<<EOF" >> $GITHUB_ENV
           sed -i -e '$a\' ./infrastructure/known-hosts
           cat ./infrastructure/known-hosts >> $GITHUB_ENV
@@ -94,9 +91,8 @@ jobs:
           done
 
       - name: Export all secrets and environment variables
+        working-directory: ${{ github.event.repository.name }}
         run: |
-          cd ./${{ github.event.repository.name }}
-
           SECRETS_JSON_WITH_NEWLINES=$(cat<<EOF
             ${{ toJSON(secrets) }}
           EOF)
@@ -133,10 +129,15 @@ jobs:
               .[]' <<< "$VARS_JSON_WITH_NEWLINES"
           )
 
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ${{ github.event.repository.name }}/.nvmrc
+
       - name: Deploy to ${{ github.event.inputs.environment }}
         id: deploy
+        working-directory: ${{ github.event.repository.name }}
         run: |
-          cd ./${{ github.event.repository.name }}
           yarn deploy \
           --clear_data=no \
           --environment=${{ github.event.inputs.environment }} \

--- a/.github/workflows/seed-data.yml
+++ b/.github/workflows/seed-data.yml
@@ -34,22 +34,21 @@ jobs:
         with:
           fetch-depth: 0
           repository: 'opencrvs/opencrvs-core'
-          path: './opencrvs-core'
 
       - name: Set CORE_VERSION from inputs
         if: ${{ github.event.inputs.core-image-tag }}
-        run: |
-          cd opencrvs-core
-          git checkout ${{ github.event.inputs.core-image-tag }}
+        run: git checkout ${{ github.event.inputs.core-image-tag }}
+
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
 
       - name: Install dependencies
-        working-directory: ./opencrvs-core
         run: yarn install
 
       - name: Seed data on given environment
-        run: |
-          cd ./opencrvs-core
-          yarn seed:prod
+        run: yarn seed:prod
         env:
           ACTIVATE_USERS: ${{ vars.ACTIVATE_USERS }}
           GATEWAY_HOST: ${{ vars.GATEWAY_HOST }}


### PR DESCRIPTION
## Description

This hot-fix aims to give a better way to configure node version between releases. See releated slack convo: https://opencrvsworkspace.slack.com/archives/C07M2FETFFB/p1749801415129169

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
