### PR TITLE
fix: continue on error to send message about it in slack

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -20,7 +20,7 @@ env:
   UPSTREAM_REPOSITORY: ${{ github.repository }}
   # Check token under Olli's account
   GH_TOKEN: ${{ secrets.FORK_ORGANISATION_TOKEN }}
-  FORK_REPOSITORY_PATH: "${{ vars.FORK_REPOSITORY_ORGANISATION }}/${{ vars.FORK_REPOSITORY_NAME }}"
+  FORK_REPOSITORY_PATH: '${{ vars.FORK_REPOSITORY_ORGANISATION }}/${{ vars.FORK_REPOSITORY_NAME }}'
 
 jobs:
   check_farajaland_branch:
@@ -74,13 +74,14 @@ jobs:
           git merge upstream/${BASE_BRANCH}
 
       - if: steps.merge.outcome == 'success'
-        name: "Push ${BASE_BRANCH} to Farajaland repository"
+        name: 'Push ${BASE_BRANCH} to Farajaland repository'
         run: |
           git remote -v
           git push origin ${BASE_BRANCH}
 
       - if: steps.merge.outcome == 'failure'
         name: Handle merge conflicts and push opencrvs-farajaland/sync-with-${{ github.event.pull_request.base.ref }}
+        continue-on-error: true
         run: |
           git merge --abort
           git checkout upstream/${BASE_BRANCH}


### PR DESCRIPTION
## Description

If a step fails, then the slack ping is never send about the error.
Add flag for the action to perform next ones

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
