### PR TITLE
fix: Clarify the country config version a country is deployment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -17,7 +17,7 @@ on:
         default: 'v1.8.0'
       countryconfig-image-tag:
         description: Your Country Config DockerHub image tag
-        default: 'n/a'
+        default: 'latest'
         required: false
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
           path: './${{ github.event.repository.name }}'
 
       - name: Checkout country branch ${{ inputs.countryconfig-image-tag }}
-        if: ${{ inputs.countryconfig-image-tag != 'n/a' && inputs.countryconfig-image-tag != '' }}
+        if: ${{ inputs.countryconfig-image-tag != 'latest' && inputs.countryconfig-image-tag != '' }}
         working-directory: ${{ github.event.repository.name }}
         run: git checkout ${{ inputs.countryconfig-image-tag }}
 
@@ -50,7 +50,7 @@ jobs:
       - name: Resolve image tags
         working-directory: ${{ github.event.repository.name }}
         run: |
-          if [ '${{ inputs.countryconfig-image-tag }}' == 'n/a' ] || [ '${{ inputs.countryconfig-image-tag }}' == '' ]
+          if [ '${{ inputs.countryconfig-image-tag }}' == 'latest' ] || [ '${{ inputs.countryconfig-image-tag }}' == '' ]
           then
             image_tag=`git rev-parse --short=7 HEAD`
             message="⚠️ You haven't provided country config image tag, using latest git hash as image tag."

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,5 +1,5 @@
 name: Deploy (production)
-run-name: Deploy to ${{ github.event.inputs.environment }} core=${{ github.event.inputs.core-image-tag }} country config=${{ github.event.inputs.countryconfig-image-tag }}
+run-name: "Deploy to ${{ inputs.environment }} with (core: ${{ inputs.core-image-tag }}, country config: ${{ inputs.countryconfig-image-tag }}, reset: ${{ inputs.reset }})"
 on:
   workflow_dispatch:
     inputs:
@@ -14,14 +14,15 @@ on:
       core-image-tag:
         description: Core DockerHub image tag
         required: true
-        default: 'v1.7.2'
+        default: 'v1.8.0'
       countryconfig-image-tag:
         description: Your Country Config DockerHub image tag
-        required: true
+        default: 'n/a'
+        required: false
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -37,13 +38,30 @@ jobs:
           fetch-depth: 0
           path: './${{ github.event.repository.name }}'
 
-      - name: Checkout country branch
+      - name: Checkout country branch ${{ inputs.countryconfig-image-tag }}
+        if: ${{ inputs.countryconfig-image-tag != 'n/a' && inputs.countryconfig-image-tag != '' }}
         working-directory: ${{ github.event.repository.name }}
-        run: git checkout ${{ github.event.inputs.countryconfig-image-tag }}
+        run: git checkout ${{ inputs.countryconfig-image-tag }}
 
-      - name: Checkout core branch
+      - name: Checkout core branch ${{ inputs.core-image-tag }}
         working-directory: opencrvs-core
-        run: git checkout ${{ github.event.inputs.core-image-tag }}
+        run: git checkout ${{ inputs.core-image-tag }}
+
+      - name: Resolve image tags
+        working-directory: ${{ github.event.repository.name }}
+        run: |
+          if [ '${{ inputs.countryconfig-image-tag }}' == 'n/a' ] || [ '${{ inputs.countryconfig-image-tag }}' == '' ]
+          then
+            image_tag=`git rev-parse --short=7 HEAD`
+            message="⚠️ You haven't provided country config image tag, using latest git hash as image tag."
+            message="$message Please make sure image with tag was built and pushed to your registry"
+          else
+            image_tag=${{ inputs.countryconfig-image-tag }}
+          fi
+
+          message="Core image tag: ${{ inputs.core-image-tag }} \n\nCountry config image tag: $image_tag \n\n $message"
+          echo -e $message | tee -a $GITHUB_STEP_SUMMARY
+          echo "image_tag=$image_tag" >> $GITHUB_ENV
 
       - name: Read known hosts
         working-directory: ${{ github.event.repository.name }}
@@ -72,13 +90,13 @@ jobs:
       - name: Wait for images to be available
         run: |
           while true; do
-            if docker manifest inspect ghcr.io/opencrvs/ocrvs-auth:${{ github.event.inputs.core-image-tag }}; then
+            if docker manifest inspect ghcr.io/opencrvs/ocrvs-auth:${{ inputs.core-image-tag }}; then
               break
             fi
             sleep 10
           done
           while true; do
-            if docker manifest inspect ${{ secrets.DOCKERHUB_ACCOUNT }}/${{ secrets.DOCKERHUB_REPO }}:${{ github.event.inputs.countryconfig-image-tag }}; then
+            if docker manifest inspect ${{ secrets.DOCKERHUB_ACCOUNT }}/${{ secrets.DOCKERHUB_REPO }}:${{ env.image_tag }}; then
               break
             fi
             sleep 10
@@ -96,7 +114,7 @@ jobs:
           # This includes SSH_KEY and KNOWN_HOSTS
           #
           while IFS= read -r secret; do
-            echo "$secret" >> .env.${{ github.event.inputs.environment }}
+            echo "$secret" >> .env.${{ inputs.environment }}
           done < <(
             jq -r '
               to_entries |
@@ -112,7 +130,7 @@ jobs:
           EOF)
 
           while IFS= read -r var; do
-            echo "$var" >> .env.${{ github.event.inputs.environment }}
+            echo "$var" >> .env.${{ inputs.environment }}
           done < <(
             jq -r '
               to_entries |
@@ -128,16 +146,17 @@ jobs:
         with:
           node-version-file: ${{ github.event.repository.name }}/.nvmrc
 
-      - name: Deploy to ${{ github.event.inputs.environment }}
+      - name: Deploy to ${{ inputs.environment }}
+        id: deploy
         working-directory: ${{ github.event.repository.name }}
         run: |
           yarn deploy \
           --clear_data=no \
-          --environment=${{ github.event.inputs.environment }} \
+          --environment=${{ inputs.environment }} \
           --host=${{ vars.DOMAIN }} \
           --ssh_host=${{ vars.SSH_HOST || secrets.SSH_HOST }} \
           --ssh_port=${{ vars.SSH_PORT || secrets.SSH_PORT }} \
           --ssh_user=${{ secrets.SSH_USER }} \
-          --version=${{ github.event.inputs.core-image-tag }} \
-          --country_config_version=${{ github.event.inputs.countryconfig-image-tag }} \
+          --version=${{ inputs.core-image-tag }} \
+          --country_config_version=${{ env.image_tag }} \
           --replicas=${{ vars.REPLICAS }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 name: Deploy (development)
-run-name: Deploy to ${{ github.event.inputs.environment }} with reset=${{ github.event.inputs.reset }} core=${{ github.event.inputs.core-image-tag }} country config=${{ github.event.inputs.countryconfig-image-tag }}
+run-name: "Deploy to ${{ inputs.environment }} with (core: ${{ inputs.core-image-tag }}, country config: ${{ inputs.countryconfig-image-tag }}, reset: ${{ inputs.reset }})"
 on:
   workflow_dispatch:
     inputs:
@@ -15,17 +15,18 @@ on:
       core-image-tag:
         description: Core DockerHub image tag
         required: true
-        default: 'v1.7.2'
+        default: 'v1.8.0'
       countryconfig-image-tag:
         description: Your Country Config DockerHub image tag
-        required: true
+        default: 'n/a'
+        required: false
       reset:
         type: boolean
         description: Reset the environment
         default: false
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
     outputs:
       outcome: ${{ steps.deploy.outcome }}
@@ -43,13 +44,30 @@ jobs:
           fetch-depth: 0
           path: './${{ github.event.repository.name }}'
 
-      - name: Checkout country branch
+      - name: Checkout country branch ${{ inputs.countryconfig-image-tag }}
+        if: ${{ inputs.countryconfig-image-tag != 'n/a' && inputs.countryconfig-image-tag != '' }}
         working-directory: ${{ github.event.repository.name }}
-        run: git checkout ${{ github.event.inputs.countryconfig-image-tag }}
+        run: git checkout ${{ inputs.countryconfig-image-tag }}
 
-      - name: Checkout core branch
+      - name: Checkout core branch ${{ inputs.core-image-tag }}
         working-directory: opencrvs-core
-        run: git checkout ${{ github.event.inputs.core-image-tag }}
+        run: git checkout ${{ inputs.core-image-tag }}
+
+      - name: Resolve image tags
+        working-directory: ${{ github.event.repository.name }}
+        run: |
+          if [ '${{ inputs.countryconfig-image-tag }}' == 'n/a' ] || [ '${{ inputs.countryconfig-image-tag }}' == '' ]
+          then
+            image_tag=`git rev-parse --short=7 HEAD`
+            message="⚠️ You haven't provided country config image tag, using latest git hash as image tag."
+            message="$message Please make sure image with tag was built and pushed to your registry"
+          else
+            image_tag=${{ inputs.countryconfig-image-tag }}
+          fi
+
+          message="Core image tag: ${{ inputs.core-image-tag }} \n\nCountry config image tag: $image_tag \n\n $message"
+          echo -e $message | tee -a $GITHUB_STEP_SUMMARY
+          echo "image_tag=$image_tag" >> $GITHUB_ENV
 
       - name: Read known hosts
         working-directory: ${{ github.event.repository.name }}
@@ -78,13 +96,13 @@ jobs:
       - name: Wait for images to be available
         run: |
           while true; do
-            if docker manifest inspect ghcr.io/opencrvs/ocrvs-auth:${{ github.event.inputs.core-image-tag }}; then
+            if docker manifest inspect ghcr.io/opencrvs/ocrvs-auth:${{ inputs.core-image-tag }}; then
               break
             fi
             sleep 10
           done
           while true; do
-            if docker manifest inspect ${{ secrets.DOCKERHUB_ACCOUNT }}/${{ secrets.DOCKERHUB_REPO }}:${{ github.event.inputs.countryconfig-image-tag }}; then
+            if docker manifest inspect ${{ secrets.DOCKERHUB_ACCOUNT }}/${{ secrets.DOCKERHUB_REPO }}:${{ env.image_tag }}; then
               break
             fi
             sleep 10
@@ -102,7 +120,7 @@ jobs:
           # This includes SSH_KEY and KNOWN_HOSTS
           #
           while IFS= read -r secret; do
-            echo "$secret" >> .env.${{ github.event.inputs.environment }}
+            echo "$secret" >> .env.${{ inputs.environment }}
           done < <(
             jq -r '
               to_entries |
@@ -118,7 +136,7 @@ jobs:
           EOF)
 
           while IFS= read -r var; do
-            echo "$var" >> .env.${{ github.event.inputs.environment }}
+            echo "$var" >> .env.${{ inputs.environment }}
           done < <(
             jq -r '
               to_entries |
@@ -134,34 +152,34 @@ jobs:
         with:
           node-version-file: ${{ github.event.repository.name }}/.nvmrc
 
-      - name: Deploy to ${{ github.event.inputs.environment }}
+      - name: Deploy to ${{ inputs.environment }}
         id: deploy
         working-directory: ${{ github.event.repository.name }}
         run: |
           yarn deploy \
           --clear_data=no \
-          --environment=${{ github.event.inputs.environment }} \
+          --environment=${{ inputs.environment }} \
           --host=${{ vars.DOMAIN }} \
           --ssh_host=${{ vars.SSH_HOST || secrets.SSH_HOST }} \
           --ssh_port=${{ vars.SSH_PORT || secrets.SSH_PORT }} \
           --ssh_user=${{ secrets.SSH_USER }} \
-          --version=${{ github.event.inputs.core-image-tag }} \
-          --country_config_version=${{ github.event.inputs.countryconfig-image-tag }} \
+          --version=${{ inputs.core-image-tag }} \
+          --country_config_version=${{ env.image_tag }} \
           --replicas=${{ vars.REPLICAS }}
 
   reset:
     needs: deploy
-    if: ${{ github.event.inputs.reset == 'true' && needs.deploy.outputs.outcome == 'success' }}
+    if: ${{ inputs.reset == 'true' && needs.deploy.outputs.outcome == 'success' }}
     uses: ./.github/workflows/clear-environment.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ inputs.environment }}
     secrets: inherit
 
   seed-data:
     needs: reset
-    if: ${{ github.event.inputs.reset == 'true' && needs.reset.outputs.outcome == 'success' }}
+    if: ${{ inputs.reset == 'true' && needs.reset.outputs.outcome == 'success' }}
     uses: ./.github/workflows/seed-data.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
-      core-image-tag: ${{ github.event.inputs.core-image-tag }}
+      environment: ${{ inputs.environment }}
+      core-image-tag: ${{ inputs.core-image-tag }}
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ on:
         default: 'v1.8.0'
       countryconfig-image-tag:
         description: Your Country Config DockerHub image tag
-        default: 'n/a'
+        default: 'latest'
         required: false
       reset:
         type: boolean
@@ -45,7 +45,7 @@ jobs:
           path: './${{ github.event.repository.name }}'
 
       - name: Checkout country branch ${{ inputs.countryconfig-image-tag }}
-        if: ${{ inputs.countryconfig-image-tag != 'n/a' && inputs.countryconfig-image-tag != '' }}
+        if: ${{ inputs.countryconfig-image-tag != 'latest' && inputs.countryconfig-image-tag != '' }}
         working-directory: ${{ github.event.repository.name }}
         run: git checkout ${{ inputs.countryconfig-image-tag }}
 
@@ -56,7 +56,7 @@ jobs:
       - name: Resolve image tags
         working-directory: ${{ github.event.repository.name }}
         run: |
-          if [ '${{ inputs.countryconfig-image-tag }}' == 'n/a' ] || [ '${{ inputs.countryconfig-image-tag }}' == '' ]
+          if [ '${{ inputs.countryconfig-image-tag }}' == 'latest' ] || [ '${{ inputs.countryconfig-image-tag }}' == '' ]
           then
             image_tag=`git rev-parse --short=7 HEAD`
             message="⚠️ You haven't provided country config image tag, using latest git hash as image tag."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.8.0
 
+- Added Build summary and refactored deployment workflow to be more clear [#6984](https://github.com/opencrvs/opencrvs-core/issues/6984)
+
 ## 1.6.4
 
 ### Bug fixes


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/6984

Country config field is optional now:
- If not provided then last commit is used from country-config branch
- If provided then country-config will use provided commit

Edge cases:
- Country config doesn't have image build from last commit hash.


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly


## Test results

### Run deployment without defining country config image tag: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15778974955

Input properties:
![image](https://github.com/user-attachments/assets/d1a00bdf-2412-4754-a646-2529e76b1fbd)

Skip checkout step:
![image](https://github.com/user-attachments/assets/c15aae1c-4cb2-4764-92b6-0f26525f46fb)

Build summary:
![image](https://github.com/user-attachments/assets/ff3aacf1-9290-4410-ab36-755525a412c2)

### Run deployment with specific version of country config image tag:

Input properties:
![image](https://github.com/user-attachments/assets/eb485b0d-567a-4b25-a48b-b15836bb2a03)

Checkout for both repositories executed:
![image](https://github.com/user-attachments/assets/25f63741-3c26-4ac6-a8c6-6442c8cfb188)

Build summary:

![image](https://github.com/user-attachments/assets/aaf66af2-f80e-4f2f-8c22-086bd8fd5a09)
