### PR TITLE
Use NAME field in V2 death forms and supporting documents fixes

### DIFF
--- a/src/api/certificates/source/v2.death-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.death-certificate-certified-copy.svg
@@ -48,7 +48,7 @@
   </text>
   <g clip-path="url(#clip0_948_2918)">
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
-      <tspan x="312" y="148.104">{{$lookup $declaration "deceased.firstname"}} {{$lookup $declaration "deceased.surname"}}</tspan>
+      <tspan x="312" y="148.104">{{$lookup $declaration "deceased.name"}}</tspan>
     </text>
   </g>
   <line x1="70" y1="154.5" x2="514" y2="154.5" stroke="#ECECEC" />
@@ -166,7 +166,7 @@
   </text>
   <g clip-path="url(#clip8_948_2918)">
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
-      <tspan x="312" y="372.104">{{$lookup $declaration "informant.firstname"}} {{$lookup $declaration "informant.surname"}}</tspan>
+      <tspan x="312" y="372.104">{{$lookup $declaration "informant.name"}}</tspan>
       <tspan x="312" y="384.104">{{$lookup $declaration "informant.relation"}}</tspan>
     </text>
   </g>

--- a/src/api/certificates/source/v2.death-certificate.svg
+++ b/src/api/certificates/source/v2.death-certificate.svg
@@ -45,7 +45,7 @@
     </text>
     <g clip-path="url(#clip3_1157_5058)">
       <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="9.7" letter-spacing="0px">
-        <tspan x="289.95" y="229.583">{{$lookup $declaration "deceased.firstname"}} {{$lookup $declaration "deceased.surname"}}</tspan>
+        <tspan x="289.95" y="229.583">{{$lookup $declaration "deceased.name"}}</tspan>
       </text>
     </g>
     <line x1="81.3999" y1="246.155" x2="512.08" y2="246.155" stroke="#ECECEC" stroke-width="0.97" />

--- a/src/form/v2/death/advancedSearch.ts
+++ b/src/form/v2/death/advancedSearch.ts
@@ -48,11 +48,9 @@ export const advancedSearchDeath = [
       field('deceased.dob', {
         searchCriteriaLabelPrefix: deceasedPrefix
       }).range(),
-      field('deceased.firstname', {
-        searchCriteriaLabelPrefix: deceasedPrefix
-      }).fuzzy(),
-      field('deceased.surname', {
-        searchCriteriaLabelPrefix: deceasedPrefix
+      field('deceased.name', {
+        validations: [],
+        conditionals: []
       }).fuzzy(),
       field('deceased.gender', {
         searchCriteriaLabelPrefix: deceasedPrefix
@@ -83,13 +81,9 @@ export const advancedSearchDeath = [
         conditionals: [],
         searchCriteriaLabelPrefix: informantPrefix
       }).range(),
-      field('informant.firstname', {
+      field('informant.name', {
         conditionals: [],
-        searchCriteriaLabelPrefix: informantPrefix
-      }).fuzzy(),
-      field('informant.surname', {
-        conditionals: [],
-        searchCriteriaLabelPrefix: informantPrefix
+        validations: []
       }).fuzzy()
     ]
   }

--- a/src/form/v2/death/forms/declaration.ts
+++ b/src/form/v2/death/forms/declaration.ts
@@ -21,7 +21,7 @@ export const DEATH_DECLARATION_REVIEW = {
   title: {
     id: 'v2.event.death.action.declare.form.review.title',
     defaultMessage:
-      '{deceased.firstname, select, __EMPTY__ {Death declaration} other {{deceased.surname, select, __EMPTY__ {Death declaration} other {Death declaration for {deceased.firstname} {deceased.surname}}}}}',
+      '{deceased.name.firstname, select, __EMPTY__ {Death declaration} other {{deceased.name.surname, select, __EMPTY__ {Death declaration} other {Death declaration for {deceased.name.firstname} {deceased.name.surname}}}}}',
     description: 'Title of the form to show in review page'
   },
   fields: [

--- a/src/form/v2/death/forms/pages/deceased.ts
+++ b/src/form/v2/death/forms/pages/deceased.ts
@@ -69,28 +69,17 @@ export const deceased = defineFormPage({
   },
   fields: [
     {
-      id: 'deceased.firstname',
-      type: FieldType.TEXT,
+      id: 'deceased.name',
+      type: FieldType.NAME,
       configuration: { maxLength: MAX_NAME_LENGTH },
       required: true,
+      hideLabel: true,
       label: {
-        defaultMessage: 'First name(s)',
+        defaultMessage: "Deceased's name",
         description: 'This is the label for the field',
-        id: 'v2.event.death.action.declare.form.section.deceased.field.firstname.label'
+        id: 'v2.event.death.action.declare.form.section.deceased.field.name.label'
       },
-      validation: [invalidNameValidator('deceased.firstname')]
-    },
-    {
-      id: 'deceased.surname',
-      type: FieldType.TEXT,
-      configuration: { maxLength: MAX_NAME_LENGTH },
-      required: true,
-      label: {
-        defaultMessage: 'Last name',
-        description: 'This is the label for the field',
-        id: 'v2.event.death.action.declare.form.section.deceased.field.surname.label'
-      },
-      validation: [invalidNameValidator('deceased.surname')]
+      validation: [invalidNameValidator('deceased.name')]
     },
     {
       id: 'deceased.gender',
@@ -191,7 +180,7 @@ export const deceased = defineFormPage({
     },
     {
       id: 'deceased.nid',
-      type: FieldType.TEXT,
+      type: FieldType.ID,
       required: true,
       label: {
         defaultMessage: 'ID Number',

--- a/src/form/v2/death/forms/pages/documents.ts
+++ b/src/form/v2/death/forms/pages/documents.ts
@@ -11,7 +11,9 @@
 
 import { createSelectOptions } from '@countryconfig/form/v2/utils'
 import {
+  ConditionalType,
   defineFormPage,
+  field,
   FieldType,
   ImageMimeType,
   PageTypes,
@@ -48,6 +50,72 @@ const idTypeMessageDescriptors = {
   }
 } satisfies Record<keyof typeof IdType, TranslationConfig>
 
+const ProofOfDeathType = {
+  ATTESTED_LETTER_OF_DEATH: 'ATTESTED_LETTER_OF_DEATH',
+  POLICE_CERTIFICATE_OF_DEATH: 'POLICE_CERTIFICATE_OF_DEATH',
+  HOSPITAL_CERTIFICATE_OF_DEATH: 'HOSPITAL_CERTIFICATE_OF_DEATH',
+  CORONERS_REPORT: 'CORONERS_REPORT',
+  BURIAL_RECEIPT: 'BURIAL_RECEIPT',
+  OTHER: 'OTHER'
+} as const
+
+const proofOfDeathMessageDescriptors = {
+  ATTESTED_LETTER_OF_DEATH: {
+    defaultMessage: 'Attested letter of death',
+    description: 'Label for select option Attested Letter of Death',
+    id: 'v2.form.field.label.docTypeLetterOfDeath'
+  },
+  POLICE_CERTIFICATE_OF_DEATH: {
+    defaultMessage: 'Police certificate of death',
+    description: 'Label for select option Police death certificate',
+    id: 'v2.form.field.label.docTypePoliceCertificate'
+  },
+  HOSPITAL_CERTIFICATE_OF_DEATH: {
+    defaultMessage: 'Hospital certificate of death',
+    description: 'Label for select option Hospital certificate of death',
+    id: 'v2.form.field.label.docTypeHospitalDeathCertificate'
+  },
+  CORONERS_REPORT: {
+    defaultMessage: "Coroner's report",
+    description: "Label for select option Coroner's report",
+    id: 'v2.form.field.label.docTypeCoronersReport'
+  },
+  BURIAL_RECEIPT: {
+    defaultMessage: 'Certified copy of burial receipt',
+    description: 'Label for select option Certified Copy of Burial Receipt',
+    id: 'v2.form.field.label.docTypeCopyOfBurialReceipt'
+  },
+  OTHER: {
+    defaultMessage: 'Other',
+    description: 'Option for form field: Type of ID',
+    id: 'v2.form.field.label.docTypeOther'
+  }
+} satisfies Record<keyof typeof ProofOfDeathType, TranslationConfig>
+
+const ProofOfCauseOfDeathType = {
+  VERBAL_AUTOPSY: 'VERBAL_AUTOPSY',
+  MEDICALLY_CERTIFIED: 'MEDICALLY_CERTIFIED',
+  OTHER: 'OTHER'
+} as const
+
+const proofOfCauseOfDeathMessageDescriptors = {
+  VERBAL_AUTOPSY: {
+    defaultMessage: 'Verbal autopsy report',
+    description: 'Option for form field: verbalAutopsy',
+    id: 'v2.form.field.label.verbalAutopsy'
+  },
+  MEDICALLY_CERTIFIED: {
+    defaultMessage: 'Medically Certified Cause of Death',
+    description: 'Option for form field: medicallyCertified',
+    id: 'v2.form.field.label.medicallyCertified'
+  },
+  OTHER: {
+    defaultMessage: 'Other',
+    description: 'Option for form field: Other',
+    id: 'v2.form.field.label.docTypeOther'
+  }
+} satisfies Record<keyof typeof ProofOfCauseOfDeathType, TranslationConfig>
+
 const DEFAULT_FILE_CONFIGURATION = {
   maxFileSize: 5 * 1024 * 1024,
   acceptedFileTypes: [
@@ -59,6 +127,15 @@ const DEFAULT_FILE_CONFIGURATION = {
 
 const idTypeOptions = createSelectOptions(IdType, idTypeMessageDescriptors)
 
+const proofOfDeathTypeOptions = createSelectOptions(
+  ProofOfDeathType,
+  proofOfDeathMessageDescriptors
+)
+
+const proofOfCauseOfDeathTypeOptions = createSelectOptions(
+  ProofOfCauseOfDeathType,
+  proofOfCauseOfDeathMessageDescriptors
+)
 export const documents = defineFormPage({
   id: 'documents',
   type: PageTypes.enum.FORM,
@@ -112,7 +189,7 @@ export const documents = defineFormPage({
         id: 'v2.event.death.action.declare.form.section.documents.field.proofOfDeath.label'
       },
       configuration: DEFAULT_FILE_CONFIGURATION,
-      options: idTypeOptions
+      options: proofOfDeathTypeOptions
     },
     {
       id: 'documents.proofOfCauseOfDeath',
@@ -124,7 +201,15 @@ export const documents = defineFormPage({
         id: 'v2.event.death.action.declare.form.section.documents.field.proofOfCauseOfDeath.label'
       },
       configuration: DEFAULT_FILE_CONFIGURATION,
-      options: idTypeOptions
+      options: proofOfCauseOfDeathTypeOptions,
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: field('eventDetails.causeOfDeathEstablished').isEqualTo(
+            true
+          )
+        }
+      ]
     }
   ]
 })

--- a/src/form/v2/death/forms/pages/informant.ts
+++ b/src/form/v2/death/forms/pages/informant.ts
@@ -23,6 +23,7 @@ import {
 import { not } from '@opencrvs/toolkit/conditionals'
 import { createSelectOptions, emptyMessage } from '../../../utils'
 import {
+  invalidNameValidator,
   MAX_NAME_LENGTH,
   nationalIdValidator
 } from '@countryconfig/form/v2/birth/validators'
@@ -150,14 +151,15 @@ export const informant = defineFormPage({
       parent: field('informant.relation')
     },
     {
-      id: 'informant.firstname',
+      id: 'informant.name',
       configuration: { maxLength: MAX_NAME_LENGTH },
-      type: FieldType.TEXT,
+      type: FieldType.NAME,
       required: true,
+      hideLabel: true,
       label: {
-        defaultMessage: 'First name(s)',
+        defaultMessage: "Informant's name",
         description: 'This is the label for the field',
-        id: 'v2.event.death.action.declare.form.section.informant.field.firstname.label'
+        id: 'v2.event.death.action.declare.form.section.informant.field.name.label'
       },
       conditionals: [
         {
@@ -165,25 +167,8 @@ export const informant = defineFormPage({
           conditional: informantOtherThanSpouse
         }
       ],
-      parent: field('informant.relation')
-    },
-    {
-      id: 'informant.surname',
-      configuration: { maxLength: MAX_NAME_LENGTH },
-      type: FieldType.TEXT,
-      required: true,
-      label: {
-        defaultMessage: 'Last name',
-        description: 'This is the label for the field',
-        id: 'v2.event.death.action.declare.form.section.informant.field.surname.label'
-      },
-      conditionals: [
-        {
-          type: ConditionalType.SHOW,
-          conditional: informantOtherThanSpouse
-        }
-      ],
-      parent: field('informant.relation')
+      parent: field('informant.relation'),
+      validation: [invalidNameValidator('informant.name')]
     },
     {
       id: 'informant.dob',
@@ -300,7 +285,7 @@ export const informant = defineFormPage({
     },
     {
       id: 'informant.nid',
-      type: FieldType.TEXT,
+      type: FieldType.ID,
       required: true,
       label: {
         defaultMessage: 'ID Number',
@@ -474,7 +459,7 @@ export const informant = defineFormPage({
     },
     {
       id: 'informant.phoneNo',
-      type: FieldType.TEXT,
+      type: FieldType.PHONE,
       required: false,
       label: {
         defaultMessage: 'Phone number',

--- a/src/form/v2/death/forms/pages/spouse.ts
+++ b/src/form/v2/death/forms/pages/spouse.ts
@@ -22,6 +22,7 @@ import {
 import { not } from '@opencrvs/toolkit/conditionals'
 import { emptyMessage } from '../../../utils'
 import {
+  invalidNameValidator,
   MAX_NAME_LENGTH,
   nationalIdValidator
 } from '@countryconfig/form/v2/birth/validators'
@@ -96,38 +97,23 @@ export const spouse = defineFormPage({
       ]
     },
     {
-      id: 'spouse.firstname',
+      id: 'spouse.name',
       configuration: { maxLength: MAX_NAME_LENGTH },
-      type: FieldType.TEXT,
+      type: FieldType.NAME,
       required: true,
+      hideLabel: true,
       label: {
-        defaultMessage: 'First name(s)',
+        defaultMessage: "Spouse's name",
         description: 'This is the label for the field',
-        id: 'v2.event.death.action.declare.form.section.spouse.field.firstname.label'
+        id: 'v2.event.death.action.declare.form.section.spouse.field.name.label'
       },
       conditionals: [
         {
           type: ConditionalType.SHOW,
           conditional: requireSpouseDetails
         }
-      ]
-    },
-    {
-      id: 'spouse.surname',
-      configuration: { maxLength: MAX_NAME_LENGTH },
-      type: FieldType.TEXT,
-      required: true,
-      label: {
-        defaultMessage: 'Last name',
-        description: 'This is the label for the field',
-        id: 'v2.event.death.action.declare.form.section.spouse.field.surname.label'
-      },
-      conditionals: [
-        {
-          type: ConditionalType.SHOW,
-          conditional: requireSpouseDetails
-        }
-      ]
+      ],
+      validation: [invalidNameValidator('spouse.name')]
     },
     {
       id: 'spouse.dob',
@@ -239,7 +225,7 @@ export const spouse = defineFormPage({
     },
     {
       id: 'spouse.nid',
-      type: FieldType.TEXT,
+      type: FieldType.ID,
       required: true,
       label: {
         defaultMessage: 'ID Number',

--- a/src/form/v2/death/forms/printForm/collector-identity-verify.ts
+++ b/src/form/v2/death/forms/printForm/collector-identity-verify.ts
@@ -47,8 +47,7 @@ export const printCertificateCollectorIdentityVerify: FieldConfig[] = [
         { fieldId: 'spouse.nid' },
         { fieldId: 'spouse.passport' },
         { fieldId: 'spouse.brn' },
-        { fieldId: 'spouse.firstname' },
-        { fieldId: 'spouse.surname' },
+        { fieldId: 'spouse.name' },
         { fieldId: 'spouse.dob' },
         { fieldId: 'spouse.nationality' }
       ]
@@ -78,8 +77,7 @@ export const printCertificateCollectorIdentityVerify: FieldConfig[] = [
         { fieldId: 'informant.nid' },
         { fieldId: 'informant.passport' },
         { fieldId: 'informant.brn' },
-        { fieldId: 'informant.firstname' },
-        { fieldId: 'informant.surname' },
+        { fieldId: 'informant.name' },
         { fieldId: 'informant.dob' },
         { fieldId: 'informant.nationality' }
       ]

--- a/src/form/v2/death/forms/printForm/collector-other.ts
+++ b/src/form/v2/death/forms/printForm/collector-other.ts
@@ -15,7 +15,11 @@ import {
   FieldConfig,
   FieldType
 } from '@opencrvs/toolkit/events'
-import { nationalIdValidator } from '../../../birth/validators'
+import {
+  invalidNameValidator,
+  MAX_NAME_LENGTH,
+  nationalIdValidator
+} from '@countryconfig/form/v2/birth/validators'
 
 export const CollectorType = {
   SOMEONE_ELSE: 'SOMEONE_ELSE'
@@ -274,13 +278,15 @@ export const printCertificateCollectorOther: FieldConfig[] = [
     ]
   },
   {
-    id: 'collector.OTHER.firstName',
-    type: FieldType.TEXT,
+    id: 'collector.OTHER.name',
+    type: FieldType.NAME,
     required: true,
+    configuration: { maxLength: MAX_NAME_LENGTH },
+    hideLabel: true,
     label: {
-      defaultMessage: 'First Name',
-      description: 'This is the label for the first name field',
-      id: 'v2.event.death.action.form.section.firstName.label'
+      defaultMessage: "Collector's name",
+      description: 'This is the label for the name field of OTHER collector',
+      id: 'v2.event.death.action.form.section.collector.other.field.name.label'
     },
     conditionals: [
       {
@@ -289,25 +295,8 @@ export const printCertificateCollectorOther: FieldConfig[] = [
           CollectorType.SOMEONE_ELSE
         )
       }
-    ]
-  },
-  {
-    id: 'collector.OTHER.lastName',
-    type: FieldType.TEXT,
-    required: true,
-    label: {
-      defaultMessage: 'Last Name',
-      description: 'This is the label for the last name field',
-      id: 'v2.event.death.action.form.section.lastName.label'
-    },
-    conditionals: [
-      {
-        type: ConditionalType.SHOW,
-        conditional: field('collector.requesterId').isEqualTo(
-          CollectorType.SOMEONE_ELSE
-        )
-      }
-    ]
+    ],
+    validation: [invalidNameValidator('collector.OTHER.name')]
   },
   {
     id: 'collector.OTHER.relationshipToChild',

--- a/src/form/v2/death/forms/printForm/collectors.ts
+++ b/src/form/v2/death/forms/printForm/collectors.ts
@@ -26,7 +26,7 @@ const spouseDoesNotExist = (informantType: InformantTypeKey) => {
     type: ConditionalType.SHOW,
     conditional: and(
       field('informant.relation').isEqualTo(informantType),
-      field('spouse.firstname').isFalsy()
+      field('spouse.name').isFalsy()
     )
   }
 }
@@ -36,7 +36,7 @@ const spouseExists = (informantType: InformantTypeKey) => {
     type: ConditionalType.SHOW,
     conditional: and(
       field('informant.relation').isEqualTo(informantType),
-      not(field('spouse.firstname').isFalsy())
+      not(field('spouse.name').isFalsy())
     )
   }
 }

--- a/src/form/v2/death/index.ts
+++ b/src/form/v2/death/index.ts
@@ -33,7 +33,7 @@ export const deathEvent = defineConfig({
   },
   dateOfEvent: field('eventDetails.date'),
   title: {
-    defaultMessage: '{deceased.firstname} {deceased.surname}',
+    defaultMessage: '{deceased.name.firstname} {deceased.name.surname}',
     description: 'This is the title of the summary',
     id: 'v2.event.death.title'
   },


### PR DESCRIPTION
## Description

Use `Name` field for person names instead of `Text` fields. This makes full name searches possible.

Fix bugs found in the `Upload supporting documents` page in the death v2 form

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
