### PR TITLE
Remove location specificity from notifications workqueue for now

### DIFF
--- a/src/api/workqueue/workqueueConfig.ts
+++ b/src/api/workqueue/workqueueConfig.ts
@@ -130,8 +130,10 @@ export const Workqueues = defineWorkqueues([
       description: 'Title of notifications workqueue'
     },
     query: {
-      flags: { anyOf: [InherentFlags.INCOMPLETE] },
-      updatedAtLocation: { type: 'exact', term: user('primaryOfficeId') }
+      flags: { anyOf: [InherentFlags.INCOMPLETE] }
+      // @TODO: add this line back after notifications API has support for locations
+      // https://github.com/opencrvs/opencrvs-core/issues/9829
+      // updatedAtLocation: { type: 'exact', term: user('primaryOfficeId') }
     },
     actions: [
       {


### PR DESCRIPTION
## Description

Remove location parameter from notifications workqueue, so that notified events appear in workqueue and QA team can test the features

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
