### PR TITLE
Ocrvs 9311 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.8.1
+
+### Bug fixes
+
+- Ensure that place of birth/death only shows active facilities/offices on the form [#9311](https://github.com/opencrvs/opencrvs-core/issues/9311)
+
 ## 1.8.0
 
 ### New features

--- a/src/form/birth/required-fields.ts
+++ b/src/form/birth/required-fields.ts
@@ -62,7 +62,7 @@ export const getPlaceOfBirthFields = (): SerializedFormField[] => [
     previewGroup: 'placeOfBirth',
     required: true,
     initialValue: '',
-    searchableResource: ['facilities'],
+    searchableResource: ['activeFacilities'],
     searchableType: ['HEALTH_FACILITY'],
     dynamicOptions: {
       resource: 'facilities'

--- a/src/form/death/required-fields.ts
+++ b/src/form/death/required-fields.ts
@@ -159,7 +159,7 @@ export const getPlaceOfDeathFields = () =>
       previewGroup: 'placeOfDeath',
       required: true,
       initialValue: '',
-      searchableResource: ['facilities'],
+      searchableResource: ['activeFacilities'],
       searchableType: ['HEALTH_FACILITY'],
       dynamicOptions: {
         resource: 'facilities'


### PR DESCRIPTION
## Description

Countries can decide to use the FHIR Location API to deactivate a health facility if it has closed down. However the place of birth / death still renders a status: "inactive" health facility.