### PR TITLE
fix: Drop /data/metabase directory

### DIFF
--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -982,7 +982,6 @@ services:
 
   dashboards:
     volumes:
-      - /data/metabase:/data/metabase
       # Exceed Docker config file 500 kb file limit, thus a volume mount
       - /opt/opencrvs/infrastructure/metabase/metabase.init.db.sql:/metabase.init.db.sql
     networks:


### PR DESCRIPTION
## Description

Metabase persistence was dropped a while ago at https://github.com/opencrvs/opencrvs-countryconfig/pull/552

By this PR we drop persistence from docker-compose as well