### PR TITLE
Remove special characters from role ids on generation

### DIFF
--- a/src/upgrade-to-1_7.ts
+++ b/src/upgrade-to-1_7.ts
@@ -188,7 +188,7 @@ async function upgradeRolesDefinitions() {
   })
 
   const rolesWithGeneratedIds = roles.map((role) => ({
-    id: snakeCase(role.label_en).toUpperCase(),
+    id: snakeCase(role.label_en.replace(/[^a-zA-Z0-9 ]/g, '')).toUpperCase(),
     label: {
       defaultMessage: role.label_en,
       description: `Name for user role ${role.label_en}`,


### PR DESCRIPTION
## Description

Addresses: https://github.com/opencrvs/opencrvs-core/issues/10049
Role ids generated from aliases can include special characters like apostrophes. 

This removes any characters other than numbers and letters when generating new role ids.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
