### PR TITLE
chore: specify postgres minor version to stabilise envs

### DIFF
--- a/infrastructure/backups/restore.sh
+++ b/infrastructure/backups/restore.sh
@@ -192,7 +192,7 @@ db.getSiblingDB('webhooks').dropDatabase();"
 docker run --rm \
   -e PGPASSWORD=$POSTGRES_PASSWORD \
   --network=$NETWORK \
-  postgres:17 \
+  postgres:17.6 \
   bash -c "psql -h postgres -U $POSTGRES_USER -c 'DROP DATABASE IF EXISTS events;'"
 
 #####
@@ -225,7 +225,7 @@ docker run --rm \
   -e PGPASSWORD=$POSTGRES_PASSWORD \
   -v $ROOT_PATH/backups/postgres:/backups \
   --network=$NETWORK \
-  postgres:17 \
+  postgres:17.6 \
   bash -c "createdb -h postgres -U $POSTGRES_USER events && pg_restore -h postgres -U $POSTGRES_USER -d events /backups/events-${LABEL}.dump"
 
 ##

--- a/infrastructure/clear-all-data.sh
+++ b/infrastructure/clear-all-data.sh
@@ -138,7 +138,7 @@ docker run --rm --network=$NETWORK  \
   -e POSTGRES_DB="${POSTGRES_DB}" \
   -e EVENTS_MIGRATOR_ROLE="${EVENTS_MIGRATOR_ROLE}" \
   -e EVENTS_APP_ROLE="${EVENTS_APP_ROLE}" \
-  postgres:17 bash -c '
+  postgres:17.6 bash -c '
 psql -h postgres -U "$POSTGRES_USER" -d postgres -v ON_ERROR_STOP=1 <<EOF
 SELECT pg_terminate_backend(pid)
 FROM pg_stat_activity

--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -961,7 +961,7 @@ services:
         tag: 'hearth'
 
   postgres:
-    image: postgres:17
+    image: postgres:17.6
     networks:
       - overlay_net
     restart: unless-stopped
@@ -979,7 +979,7 @@ services:
           - node.labels.data1 == true
 
   postgres-on-update:
-    image: postgres:17
+    image: postgres:17.6
     command: bash /on-deploy.sh
     configs:
       - source: postgres-on-deploy.{{ts}}


### PR DESCRIPTION
## Description

1. Specify minor version to avoid changes in env.
Issue:
- Deployment was succesful. First clear errors happened during environment reset.
- Reset process halted and left the environment in half-finished (broken) state.
Cause:
- We use postgres image: postgres:17
- Image source was updated some days ago by postgres team
- image update changed base image and underlying OS dependency (collation) version was updated.
- postgres depends on it for indexing. System threw an error when version mismatch was detected.
- Clearing script drops events database but default databases (postgres, template1) remain.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
