### PR TITLE
fix: Change Valkey to Redis

### DIFF
--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -254,8 +254,8 @@ services:
   # Configure redis
   redis:
     environment:
-      - VALKEY_PASSWORD=false
-      - VALKEY_ACLFILE=/run/secrets/redis-acl.{{ts}}
+      - REDIS_PASSWORD=false
+      - REDIS_ACLFILE=/run/secrets/redis-acl.{{ts}}
     secrets:
       - redis-acl.{{ts}}
     networks:


### PR DESCRIPTION
## Description

wrong lines of code was introduced while merge release branch into develop: https://github.com/opencrvs/opencrvs-countryconfig/commit/daab07d9ff4f73f5147f823c186f79844abf1b33#diff-ba8e76e28deb79c9af80270674a0f04af642ba68d7b1c608ed5790db9cc6f4c8

OpenCRVS v1.8.1 doesn't have authorisation enabled for redis (or Valkey)

See latest changelog at https://github.com/opencrvs/opencrvs-core/blob/develop/CHANGELOG.md

Redis ACLs are well tested and working in latest code on Farajaland fork: https://github.com/opencrvs/opencrvs-farajaland/commit/6d131430ba97e374159f249019f1130780c99a94


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
