### PR TITLE
chore: show events in sent for review independent of status

### DIFF
--- a/src/api/workqueue/workqueueConfig.ts
+++ b/src/api/workqueue/workqueueConfig.ts
@@ -1,6 +1,7 @@
 import {
   ActionStatus,
   ActionType,
+  EventStatus,
   InherentFlags,
   defineWorkqueues,
   event,
@@ -162,7 +163,6 @@ export const Workqueues = defineWorkqueues([
       description: 'Title of sent for review workqueue'
     },
     query: {
-      status: { type: 'anyOf', terms: ['DECLARED', 'NOTIFIED'] },
       flags: {
         noneOf: [InherentFlags.REJECTED]
       },
@@ -195,7 +195,7 @@ export const Workqueues = defineWorkqueues([
       description: 'Title of ready for review workqueue'
     },
     query: {
-      status: { type: 'exact', term: 'DECLARED' },
+      status: { type: 'exact', term: EventStatus.enum.DECLARED },
       flags: {
         noneOf: [InherentFlags.REJECTED]
       },


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/issues/10085
Remove the status limit from sent for review

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
