### PR TITLE
chore: update default value of father address field

### DIFF
--- a/src/form/v2/birth/forms/pages/father.ts
+++ b/src/form/v2/birth/forms/pages/father.ts
@@ -343,7 +343,7 @@ export const father = defineFormPage({
         id: 'v2.event.birth.action.declare.form.section.father.field.address.addressSameAs.label'
       },
       parent: field('mother.detailsNotAvailable'),
-      defaultValue: YesNoTypes.YES,
+      defaultValue: YesNoTypes.NO,
       conditionals: [
         {
           type: ConditionalType.SHOW,

--- a/src/form/v2/birth/forms/pages/father.ts
+++ b/src/form/v2/birth/forms/pages/father.ts
@@ -343,6 +343,7 @@ export const father = defineFormPage({
         id: 'v2.event.birth.action.declare.form.section.father.field.address.addressSameAs.label'
       },
       parent: field('mother.detailsNotAvailable'),
+      // Keep default address when mother details is updated
       defaultValue: YesNoTypes.NO,
       conditionals: [
         {


### PR DESCRIPTION
## Description

Fix of https://github.com/opencrvs/opencrvs-core/issues/10293#issuecomment-3236485893

`parent: field('mother.detailsNotAvailable)` when a parent field is updated, the value of the field itself gets reset. So when we click the CHECKBOX of the `mother.detailsAvailable`, `father.addressSameAs` is reset and set to defaultValue which is `Yes` and its original address gets hidden. 

**Solution**: We change the `dafaultValue` of the field `father.addressSameAs` so that original address is not reset.  

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
