### PR TITLE
There wont be any default call to action button in sent for approval workqueue

### DIFF
--- a/src/api/workqueue/workqueueConfig.ts
+++ b/src/api/workqueue/workqueueConfig.ts
@@ -357,12 +357,7 @@ export const Workqueues = defineWorkqueues([
         }
       ]
     },
-    actions: [
-      {
-        type: 'DEFAULT',
-        conditionals: []
-      }
-    ],
+    actions: [],
     columns: [
       DATE_OF_EVENT_COLUMN,
       {


### PR DESCRIPTION
## Description
issue: https://github.com/opencrvs/opencrvs-core/issues/10006#issuecomment-3248598452

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
