### PR TITLE
fix: docker.io/***/***:c28a386 is a manifest list

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -54,7 +54,7 @@ jobs:
           if [[ "${{ matrix.runner }}" == "ubuntu-24.04-arm" ]]; then
             echo "version=${GIT_HASH}-arm64" >> $GITHUB_OUTPUT
           else
-            echo "version=${GIT_HASH}" >> $GITHUB_OUTPUT
+            echo "version=${GIT_HASH}-amd64" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push
@@ -79,7 +79,7 @@ jobs:
         run: |
             TAG="${{ needs.build.outputs.version_common }}"
             REPO="${{ secrets.DOCKERHUB_ACCOUNT}}/${{ secrets.DOCKERHUB_REPO }}"
-            MANIFEST_LIST="--amend $REPO:$TAG --amend $REPO:$TAG-arm64"
+            MANIFEST_LIST="$REPO:$TAG-amd64 $REPO:$TAG-arm64"
             if [[ "$BRANCH_NAME" == "develop" ]]; then
               echo "[🔁 pushing ] $REPO:$TAG"
               docker manifest create $REPO:develop \


### PR DESCRIPTION
## Description

This PR aims to address the issue for multi-arch manifests created with `docker manifest create`: https://github.com/opencrvs/opencrvs-countryconfig/actions/runs/17555349167/job/49858711010


## Test results

### Build from custom branch

✅ https://github.com/opencrvs/opencrvs-countryconfig/actions/runs/17556014643

### Build from custom tag

✅ https://github.com/opencrvs/opencrvs-countryconfig/actions/runs/17556134832

### Build from develop branch

✅ https://github.com/opencrvs/opencrvs-countryconfig/actions/runs/17556017848


> NOTE: there is no need to update changelog