### PR TITLE
Extend dedupConfig to match mother by NID, passport, or BRN

### DIFF
--- a/src/form/v2/birth/dedupConfig.ts
+++ b/src/form/v2/birth/dedupConfig.ts
@@ -15,6 +15,13 @@ const childDobWithin5Days = field('child.dob').dateRangeMatches({ days: 5 })
 const similarNamedMother = field('mother.name').fuzzyMatches()
 const similarAgedMother = field('mother.dob').dateRangeMatches({ days: 365 })
 const sameMotherNid = field('mother.nid').strictMatches()
+const sameMotherPassport = field('mother.passport').strictMatches()
+const sameMotherBrn = field('mother.brn').strictMatches()
+const sameMotherIdentifier = or(
+  sameMotherNid,
+  sameMotherPassport,
+  sameMotherBrn
+)
 const childDobWithin9Months = field('child.dob').dateRangeMatches({
   days: 270
 })
@@ -29,12 +36,12 @@ export const dedupConfig = or(
     childDobWithin5Days,
     similarNamedMother,
     similarAgedMother,
-    sameMotherNid
+    sameMotherIdentifier
   ),
   and(
     similarNamedMother,
     similarAgedMother,
-    sameMotherNid,
+    sameMotherIdentifier,
     childDobWithin9Months
   ),
   and(
@@ -42,6 +49,6 @@ export const dedupConfig = or(
     childDobWithin3Years,
     similarNamedMother,
     similarAgedMother,
-    sameMotherNid
+    sameMotherIdentifier
   )
 )

--- a/src/form/v2/birth/dedupConfig.ts
+++ b/src/form/v2/birth/dedupConfig.ts
@@ -14,13 +14,10 @@ const similarNamedChild = field('child.name').fuzzyMatches()
 const childDobWithin5Days = field('child.dob').dateRangeMatches({ days: 5 })
 const similarNamedMother = field('mother.name').fuzzyMatches()
 const similarAgedMother = field('mother.dob').dateRangeMatches({ days: 365 })
-const sameMotherNid = field('mother.nid').strictMatches()
-const sameMotherPassport = field('mother.passport').strictMatches()
-const sameMotherBrn = field('mother.brn').strictMatches()
 const sameMotherIdentifier = or(
-  sameMotherNid,
-  sameMotherPassport,
-  sameMotherBrn
+  field('mother.nid').strictMatches(),
+  field('mother.passport').strictMatches(),
+  field('mother.brn').strictMatches()
 )
 const childDobWithin9Months = field('child.dob').dateRangeMatches({
   days: 270


### PR DESCRIPTION
## Description

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
