### PR TITLE
fix: prevent low-level users from reading any event

### DIFF
--- a/src/data-seeding/roles/roles.ts
+++ b/src/data-seeding/roles/roles.ts
@@ -29,7 +29,6 @@ export const roles: Role[] = [
       'search[event=tennis-club-membership,access=all]',
       'workqueue[id=assigned-to-you|recent|requires-updates-self|sent-for-review]',
       `record.create[event=birth|death|tennis-club-membership]`,
-      'record.read[event=birth|death|tennis-club-membership]',
       'record.declare[event=birth|death|tennis-club-membership]',
       'record.notify[event=birth|death|tennis-club-membership]'
     ]
@@ -54,7 +53,6 @@ export const roles: Role[] = [
       'search[event=death,access=all]',
       'search[event=tennis-club-membership,access=all]',
       `record.create[event=birth|death|tennis-club-membership]`,
-      'record.read[event=birth|death|tennis-club-membership]',
       'record.declare[event=birth|death|tennis-club-membership]',
       'record.notify[event=birth|death|tennis-club-membership]'
     ]
@@ -80,7 +78,6 @@ export const roles: Role[] = [
       'search[event=tennis-club-membership,access=all]',
       'workqueue[id=assigned-to-you|recent|requires-updates-self|sent-for-review]',
       `record.create[event=birth|death|tennis-club-membership]`,
-      'record.read[event=birth|death|tennis-club-membership]',
       'record.declare[event=birth|death|tennis-club-membership]',
       'record.notify[event=birth|death|tennis-club-membership]'
     ]
@@ -105,7 +102,6 @@ export const roles: Role[] = [
       'search[event=death,access=all]',
       'search[event=tennis-club-membership,access=all]',
       `record.create[event=birth|death|tennis-club-membership]`,
-      'record.read[event=birth|death|tennis-club-membership]',
       'record.declare[event=birth|death|tennis-club-membership]',
       'record.notify[event=birth|death|tennis-club-membership]'
     ]
@@ -130,7 +126,6 @@ export const roles: Role[] = [
       'search[event=death,access=all]',
       'search[event=tennis-club-membership,access=all]',
       `record.create[event=birth|death|tennis-club-membership]`,
-      'record.read[event=birth|death|tennis-club-membership]',
       'record.declare[event=birth|death|tennis-club-membership]',
       'record.notify[event=birth|death|tennis-club-membership]'
     ]


### PR DESCRIPTION
## Description
Remove read option from low level users by default. They can still read the ones created by them

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
