### PR TITLE
fix: Build ARM images only on release tag or manually

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: ${{ 
-          ((github.ref_type == 'tag' || github.event.inputs.build_arm == true) && fromJSON('["ubuntu-24.04", "ubuntu-24.04-arm"]')) || 
+          ((github.ref_type == 'tag' || inputs.build_arm == true) && fromJSON('["ubuntu-24.04", "ubuntu-24.04-arm"]')) || 
           fromJSON('["ubuntu-24.04"]') 
           }}
     outputs:
@@ -35,13 +35,13 @@ jobs:
       version_common: ${{ steps.country_config.outputs.version_common }}
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: github.event_name == 'workflow_dispatch'
         with:
           fetch-depth: 2
-          ref: '${{ github.event.inputs.branch_name }}'
+          ref: '${{ inputs.branch_name }}'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: github.event_name == 'push'
 
       - name: Get tags
@@ -58,7 +58,7 @@ jobs:
         env:
           DOCKERHUB_ACCOUNT: ${{ secrets.DOCKERHUB_ACCOUNT }}
           DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_REPO }}
-          BRANCH_NAME: ${{ github.event.inputs.branch_name || github.ref_name }}
+          BRANCH_NAME: ${{ inputs.branch_name || github.ref_name }}
         run: |
           # Check if the current commit has a tag and use it; otherwise, use the short SHA of the HEAD commit
           GIT_HASH=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short=7 HEAD)
@@ -89,8 +89,8 @@ jobs:
 
       - name: Create and push multi-arch manifest
         env:
-          BRANCH_NAME: ${{ github.event.inputs.branch_name || github.ref_name }}
-          BUILD_ARM: ${{ github.ref_type == 'tag' || github.event.inputs.build_arm == true }}
+          BRANCH_NAME: ${{ inputs.branch_name || github.ref_name }}
+          BUILD_ARM: ${{ github.ref_type == 'tag' || inputs.build_arm == true }}
         run: |
           TAG="${{ needs.build.outputs.version_common }}"
           REPO="${{ secrets.DOCKERHUB_ACCOUNT}}/${{ secrets.DOCKERHUB_REPO }}"


### PR DESCRIPTION
## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/10441

Updated the Docker image publishing workflow to conditionally build ARM64 images based on team requirements:

### What Changed
- **Conditional ARM builds**: ARM64 images are now built only when:
  - New tags are pushed (automatic trigger)
  - Manual workflow dispatch with `build_arm: true` flag
- **Added workflow input**: New `build_arm` boolean parameter for manual control
- **Enhanced triggers**: Added tag push events to automatically trigger ARM builds
- **Dynamic matrix strategy**: Runner selection now depends on conditions rather than static configuration
- **Updated manifest creation**: Multi-arch manifests are created only when ARM images exist

### Root Cause & Context
The previous workflow always attempted to build ARM64 images on release branches, which was unnecessary for most development workflows and consumed extra CI resources. The team clarified that ARM64 images are primarily needed for production releases (tags) with an option for manual builds during testing.

### Technical Implementation
- Matrix strategy uses conditional JSON arrays: `ubuntu-24.04` always included, `ubuntu-24.04-arm` added when conditions are met
- Branch name detection fixed to use `github.event.inputs.branch_name || github.ref_name` for consistency
- Manifest creation logic updated to handle both single-arch (AMD64 only) and multi-arch scenarios

### Behavior Changes
- **Before**: ARM builds on all `release*` branches
- **After**: ARM builds only on tag pushes OR manual trigger with flag
- **Resource Impact**: Reduced unnecessary ARM builds, faster CI for regular development

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests:
       - ARM flag is set to true: https://github.com/opencrvs/opencrvs-countryconfig/actions/runs/17641148408
       - ARM flag is false: https://github.com/opencrvs/opencrvs-countryconfig/actions/runs/17641100440
       - Arm images was build on tag push: https://github.com/opencrvs/opencrvs-countryconfig/actions/runs/17643146064
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths): n/a
- [ ] I have updated the changelog with this change (if applicable): n/a
- [ ] I have updated the GitHub issue status accordingly: n/a
