### PR TITLE
fix: Here-doc warning for new lines

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -105,41 +105,14 @@ jobs:
       - name: Export all secrets and environment variables
         working-directory: ${{ github.event.repository.name }}
         run: |
-          SECRETS_JSON_WITH_NEWLINES=$(cat<<EOF
-            ${{ toJSON(secrets) }}
-          EOF)
-
-          #
-          # Secrets & variables with newlines are filtered out automatically
-          # This includes SSH_KEY and KNOWN_HOSTS
-          #
-          while IFS= read -r secret; do
-            echo "$secret" >> .env.${{ inputs.environment }}
-          done < <(
-            jq -r '
-              to_entries |
-              map(
-                select(.value | test("\n") | not) |
-                "\(.key)=\"\(.value)\""
-              ) |
-              .[]' <<< "$SECRETS_JSON_WITH_NEWLINES"
-          )
-
-          VARS_JSON_WITH_NEWLINES=$(cat<<EOF
-            ${{ toJSON(vars) }}
-          EOF)
-
-          while IFS= read -r var; do
-            echo "$var" >> .env.${{ inputs.environment }}
-          done < <(
-            jq -r '
-              to_entries |
-              map(
-                select(.value | test("\n") | not) |
-                "\(.key)=\"\(.value)\""
-              ) |
-              .[]' <<< "$VARS_JSON_WITH_NEWLINES"
-          )
+          jq -n -r '
+              [${{ toJSON(secrets) }}, ${{ toJSON(vars) }}] 
+              | add
+              | to_entries
+              | map(select(.value | test("\n") | not))
+              | map("\(.key)=\"\(.value)\"")
+              | .[]
+          ' > .env.${{ inputs.environment }}
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,41 +112,14 @@ jobs:
       - name: Export all secrets and environment variables
         working-directory: ${{ github.event.repository.name }}
         run: |
-          SECRETS_JSON_WITH_NEWLINES=$(cat<<EOF
-            ${{ toJSON(secrets) }}
-          EOF)
-
-          #
-          # Secrets & variables with newlines are filtered out automatically
-          # This includes SSH_KEY and KNOWN_HOSTS
-          #
-          while IFS= read -r secret; do
-            echo "$secret" >> .env.${{ inputs.environment }}
-          done < <(
-            jq -r '
-              to_entries |
-              map(
-                select(.value | test("\n") | not) |
-                "\(.key)=\"\(.value)\""
-              ) |
-              .[]' <<< "$SECRETS_JSON_WITH_NEWLINES"
-          )
-
-          VARS_JSON_WITH_NEWLINES=$(cat<<EOF
-            ${{ toJSON(vars) }}
-          EOF)
-
-          while IFS= read -r var; do
-            echo "$var" >> .env.${{ inputs.environment }}
-          done < <(
-            jq -r '
-              to_entries |
-              map(
-                select(.value | test("\n") | not) |
-                "\(.key)=\"\(.value)\""
-              ) |
-              .[]' <<< "$VARS_JSON_WITH_NEWLINES"
-          )
+          jq -n -r '
+              [${{ toJSON(secrets) }}, ${{ toJSON(vars) }}] 
+              | add
+              | to_entries
+              | map(select(.value | test("\n") | not))
+              | map("\(.key)=\"\(.value)\"")
+              | .[]
+          ' > .env.${{ inputs.environment }}
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Description

### 🔧 Refactor: Streamline environment variable export process

Warning example: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/17670049818/job/50219598603
<img width="1517" height="150" alt="image" src="https://github.com/user-attachments/assets/8e537df7-94b5-4648-9f39-9c4979575c90" />


**What changed:**
- Replaced complex bash loop with heredocs and multiple `jq` calls with a single, efficient `jq` command
- Combined secrets and variables processing into one operation
- Maintained the same filtering logic (excludes values containing newlines like SSH keys)

**Benefits:**
- **Cleaner code**: Reduced ~30 lines to ~8 lines
- **Better performance**: Single `jq` execution instead of multiple processes
- **Improved readability**: Eliminated complex bash loops and heredoc syntax
- **Same functionality**: Preserves newline filtering and output format

**Technical details:**
- Uses `jq -n` (null input) with GitHub Actions' `toJSON()` functions
- Merges secrets and vars objects with `add`
- Applies identical filtering: `select(.value | test("\n") | not)`
- Outputs same format: `KEY="value"` pairs to `.env.${{ inputs.environment }}`

**Testing:**
- [x] Verify environment file generation works correctly: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/17678189353/job/50245563967
- [x] Confirm secrets with newlines are still filtered out:
       <img width="1033" height="502" alt="image" src="https://github.com/user-attachments/assets/e78d0787-b190-42c9-9c97-b0a2d3cf7e5c" />
- [x] Check that both secrets and variables are included in output: See previous screenshot

This refactor maintains full backward compatibility while significantly improving code maintainability.

## Checklist

- [x] I have linked the correct Github issue under "Development": This PR is result of back-porting from Kubernetes: https://github.com/opencrvs/infrastructure/pull/80
- [x] I have tested the changes locally, and written appropriate tests: See test results attached
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths): Additional tests were performed in scope of https://github.com/opencrvs/infrastructure/pull/80
- [ ] I have updated the changelog with this change (if applicable): n/a
- [ ] I have updated the GitHub issue status accordingly: n/a
