### PR TITLE
Correction form supporting docs file field is not required

### DIFF
--- a/src/form/v2/birth/forms/correctionForm/index.ts
+++ b/src/form/v2/birth/forms/correctionForm/index.ts
@@ -174,7 +174,6 @@ export const CORRECTION_FORM = defineActionForm({
         {
           id: 'documents.supportingDocs',
           type: FieldType.FILE_WITH_OPTIONS,
-          required: true,
           label: {
             defaultMessage: 'Supporting documents',
             description: 'Label for the supporting documents field',

--- a/src/form/v2/death/forms/correctionForm/index.ts
+++ b/src/form/v2/death/forms/correctionForm/index.ts
@@ -174,7 +174,6 @@ export const DEATH_CORRECTION_FORM = defineActionForm({
         {
           id: 'documents.supportingDocs',
           type: FieldType.FILE_WITH_OPTIONS,
-          required: true,
           label: {
             defaultMessage: 'Supporting documents',
             description: 'Label for the supporting documents field',


### PR DESCRIPTION
## Description

This had been misconfigured, I think one previous issue had some outdated information.

No gh issue.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
