### PR TITLE
fix: yarn environment:init should create Postgres secrets

### DIFF
--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -1211,6 +1211,40 @@ const SPECIAL_NON_APPLICATION_ENVIRONMENTS = ['jump', 'backup']
       scope: 'ENVIRONMENT' as const
     },
     {
+      name: 'POSTGRES_USER',
+      type: 'SECRET' as const,
+      didExist: findExistingValue(
+        'POSTGRES_USER',
+        'SECRET',
+        'ENVIRONMENT',
+        existingValues
+      ),
+      value: findExistingOrDefine(
+        'POSTGRES_USER',
+        'SECRET',
+        'ENVIRONMENT',
+        generateLongPassword()
+      ),
+      scope: 'ENVIRONMENT' as const
+    },
+    {
+      name: 'POSTGRES_PASSWORD',
+      type: 'SECRET' as const,
+      didExist: findExistingValue(
+        'POSTGRES_PASSWORD',
+        'SECRET',
+        'ENVIRONMENT',
+        existingValues
+      ),
+      value: findExistingOrDefine(
+        'POSTGRES_PASSWORD',
+        'SECRET',
+        'ENVIRONMENT',
+        generateLongPassword()
+      ),
+      scope: 'ENVIRONMENT' as const
+    },
+    {
       name: 'SUPER_USER_PASSWORD',
       type: 'SECRET' as const,
       didExist: findExistingValue(


### PR DESCRIPTION
Related github issue: https://github.com/opencrvs/opencrvs-core/issues/10426

## Description

This PR adds postgress admin secrets to github environment secrets

> NOTE: This PR doesn't modify logic of ENCRYPTION_KEY & BACKUP_ENCRYPTION_PASSPHRASE life-cycle since they are already read-only. There is no way to update listed secrets by `yarn ...`

## Testing

Testing was performed under Farajaland repository

New dummy environment was created: `dev1`

`yarn environment:init` was pointed to `dev1` on `Other` selection:

<img width="611" height="167" alt="image" src="https://github.com/user-attachments/assets/e89bac49-0073-450c-8fe5-971017190f1b" />

Screenshots from environment creation stage:
<img width="877" height="700" alt="image" src="https://github.com/user-attachments/assets/449b9d62-59d6-49a7-a3b2-8a0b360e7ef5" />
<img width="831" height="764" alt="image" src="https://github.com/user-attachments/assets/66fef441-5820-4527-a8ec-66700b83837e" />
<img width="794" height="765" alt="image" src="https://github.com/user-attachments/assets/f331efa1-3f55-4277-8d52-b249d449ea2d" />

<img width="559" height="80" alt="image" src="https://github.com/user-attachments/assets/fabc3e89-0591-43f5-ab69-49b47d09781f" />

## Validation
Post creation screenshots:
<img width="1335" height="388" alt="image" src="https://github.com/user-attachments/assets/4ed59f96-3b95-448d-a7fe-739d7cfd6a33" />

Values created by environments:init script:
<img width="366" height="52" alt="image" src="https://github.com/user-attachments/assets/4cead748-cb56-48ce-86e9-c32b057abfac" />


postgres container values:
<img width="669" height="173" alt="image" src="https://github.com/user-attachments/assets/dbdd7c10-9560-4826-bfde-a5c898aac63d" />


Provision: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/17731354214

Deployment: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/17732282427/job/50385850319

Seed: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/17732726286

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable): changelog changes are related to postgres integration, they are already there
- [x] I have updated the GitHub issue status accordingly
