### PR TITLE
run postgres in Docker instead of locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "vitest",
     "test:compilation": "tsc --noEmit",
     "lint": "eslint -c .eslintrc.js",
-    "setup-analytics": "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres ANALYTICS_POSTGRES_USER=events_analytics ANALYTICS_POSTGRES_PASSWORD=analytics_password bash infrastructure/postgres/setup-analytics.sh",
+    "setup-analytics": "docker exec -i -e POSTGRES_HOST=localhost -e POSTGRES_PORT=5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e ANALYTICS_POSTGRES_USER=events_analytics -e ANALYTICS_POSTGRES_PASSWORD=analytics_password postgres bash -s < ./infrastructure/postgres/setup-analytics.sh",
     "start": "yarn setup-analytics && cross-env NODE_ENV=development NODE_OPTIONS=--dns-result-order=ipv4first nodemon --exec ts-node -r tsconfig-paths/register src/index.ts",
     "start:prod": "ts-node --transpile-only -r tsconfig-paths/register src/index.ts",
     "metabase": "bash infrastructure/metabase/run-dev.sh",


### PR DESCRIPTION
## Description

The previous script required you to install `psql`, which is not necessary due to Docker already having it. Lets run the `psql` commands inside the Postgres container to fix having to install PostgreSQL locally.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
