### PR TITLE
use secured fields in death form

### DIFF
--- a/src/form/v2/death/forms/pages/deceased.ts
+++ b/src/form/v2/death/forms/pages/deceased.ts
@@ -286,6 +286,7 @@ export const deceased = defineFormPage({
       id: `deceased.address`,
       type: FieldType.ADDRESS,
       hideLabel: true,
+      secured: true,
       label: {
         defaultMessage: 'Usual place of residence',
         description: 'This is the label for the field',

--- a/src/form/v2/death/forms/pages/eventDetails.ts
+++ b/src/form/v2/death/forms/pages/eventDetails.ts
@@ -147,6 +147,7 @@ export const eventDetails = defineFormPage({
       id: 'eventDetails.date',
       type: FieldType.DATE,
       required: true,
+      secured: true,
       validation: [
         {
           message: {
@@ -277,6 +278,7 @@ export const eventDetails = defineFormPage({
       id: 'eventDetails.placeOfDeath',
       type: FieldType.SELECT,
       required: true,
+      secured: true,
       label: {
         defaultMessage: 'Place of death',
         description: 'This is the label for the field',
@@ -288,6 +290,7 @@ export const eventDetails = defineFormPage({
       id: 'eventDetails.deathLocation',
       type: FieldType.FACILITY,
       required: true,
+      secured: true,
       label: {
         defaultMessage: 'Health Institution',
         description: 'This is the label for the field',
@@ -306,6 +309,7 @@ export const eventDetails = defineFormPage({
       id: 'eventDetails.deathLocationOther',
       type: FieldType.ADDRESS,
       hideLabel: true,
+      secured: true,
       label: {
         defaultMessage: 'Death location address',
         description: 'This is the label for the field',

--- a/src/form/v2/death/forms/pages/informant.ts
+++ b/src/form/v2/death/forms/pages/informant.ts
@@ -474,6 +474,7 @@ export const informant = defineFormPage({
       id: 'informant.phoneNo',
       type: FieldType.PHONE,
       required: false,
+      secured: true,
       label: {
         defaultMessage: 'Phone number',
         description: 'This is the label for the field',
@@ -500,6 +501,7 @@ export const informant = defineFormPage({
       id: 'informant.email',
       type: FieldType.EMAIL,
       required: true,
+      secured: true,
       label: {
         defaultMessage: 'Email',
         description: 'This is the label for the field',


### PR DESCRIPTION
## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/10221

Define certain death form PII fields as `secured: true`

<img width="1484" height="746" alt="Screenshot 2025-09-22 at 9 22 05" src="https://github.com/user-attachments/assets/4a52eab3-e32b-4cf8-982e-a481bc4c2432" />

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
