### PR TITLE
[OCRVS-10536] In notifications workqueue, only show records that were created or updated in user's office

### DIFF
--- a/src/api/workqueue/workqueueConfig.ts
+++ b/src/api/workqueue/workqueueConfig.ts
@@ -137,10 +137,8 @@ export const Workqueues = defineWorkqueues([
       flags: {
         anyOf: [InherentFlags.INCOMPLETE],
         noneOf: [InherentFlags.REJECTED]
-      }
-      // @TODO: add this line back after notifications API has support for locations
-      // https://github.com/opencrvs/opencrvs-core/issues/9829
-      // updatedAtLocation: { type: 'exact', term: user('primaryOfficeId') }
+      },
+      updatedAtLocation: { type: 'exact', term: user('primaryOfficeId') }
     },
     actions: [
       {


### PR DESCRIPTION
## Description

The query made by the client previously didn't have any limit for in which office the record is in / has been updated in.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
