### PR TITLE
Fix statistics schema

### DIFF
--- a/infrastructure/postgres/setup-analytics.sh
+++ b/infrastructure/postgres/setup-analytics.sh
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS analytics.location_statistics (
   name text,
   reference_id text NOT NULL,
   year int NOT NULL,
-  crude_birth_rate int NOT NULL,
+  crude_birth_rate NUMERIC(4,1) NOT NULL,
   male_population int NOT NULL,
   female_population int NOT NULL,
   total_population int NOT NULL,


### PR DESCRIPTION
### Location seeding in analytics means countryconfig service wont start

Crude birth rate is a decimal in most countries.  E.G. 30.1 in Uganda. Unless this schema is changed, countryconfig service wont start up
