### PR TITLE
drop database with force

### DIFF
--- a/infrastructure/clear-all-data.sh
+++ b/infrastructure/clear-all-data.sh
@@ -140,11 +140,7 @@ docker run --rm --network=$NETWORK  \
   -e EVENTS_APP_ROLE="${EVENTS_APP_ROLE}" \
   postgres:17.6 bash -c '
 psql -h postgres -U "$POSTGRES_USER" -d postgres -v ON_ERROR_STOP=1 <<EOF
-SELECT pg_terminate_backend(pid)
-FROM pg_stat_activity
-WHERE datname = '\''"$POSTGRES_DB"'\'' AND pid <> pg_backend_pid();
-
-DROP DATABASE IF EXISTS "$POSTGRES_DB";
+DROP DATABASE IF EXISTS "$POSTGRES_DB" WITH (FORCE);
 
 DROP ROLE IF EXISTS "$EVENTS_MIGRATOR_ROLE";
 DROP ROLE IF EXISTS "$EVENTS_APP_ROLE";


### PR DESCRIPTION
## Description

Fixes these kinds of issues: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/17955979385/job/51068847851

Discussion: https://opencrvsworkspace.slack.com/archives/C02LU432JGK/p1758547621177389?thread_ts=1758545614.850259&cid=C02LU432JGK

```
🔁 Dropping database 'events' and roles...
 pg_terminate_backend 
----------------------
(0 rows)
```

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
