### PR TITLE
update toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/toolkit": "1.8.1-rc.4f5c826",
+    "@opencrvs/toolkit": "1.8.1-rc.fa0e315",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",
     "@types/fhir": "^0.0.30",

--- a/src/api/notification/notification.informant.email.test.ts
+++ b/src/api/notification/notification.informant.email.test.ts
@@ -13,7 +13,7 @@ vi.mock('node-fetch', () => {
 vi.mock('@opencrvs/toolkit/api', () => ({
   createClient: vi.fn(() => ({
     locations: {
-      get: {
+      list: {
         query: vi.fn().mockResolvedValue([
           {
             id: '9e069dda-0d83-4f67-a4f2-9adbf5658e2e',

--- a/src/api/notification/notification.informant.sms.test.ts
+++ b/src/api/notification/notification.informant.sms.test.ts
@@ -34,7 +34,7 @@ vi.mock('node-fetch', () => {
 vi.mock('@opencrvs/toolkit/api', () => ({
   createClient: vi.fn(() => ({
     locations: {
-      get: {
+      list: {
         query: vi.fn().mockResolvedValue([
           {
             id: '9e069dda-0d83-4f67-a4f2-9adbf5658e2e',

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,10 +834,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opencrvs/toolkit@1.8.1-rc.4f5c826":
-  version "1.8.1-rc.4f5c826"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.8.1-rc.4f5c826.tgz#859e599232a24cf0101a2b802fdf9a4942629cf1"
-  integrity sha512-+5CLQ0XXFpGWN3uUKRDehdkzNylMAJSoZRJEjpegPN8MrLAJh+u7tjdsqSbBF6uy92b2gPFO4v2M4hxLhGp2vQ==
+"@opencrvs/toolkit@1.8.1-rc.fa0e315":
+  version "1.8.1-rc.fa0e315"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.8.1-rc.fa0e315.tgz#8192e0d68f5abfe94917871ecf7b2da2f4ea2718"
+  integrity sha512-ajRySayWMTOHCXg0vwoCbeWEKrK6yQjjE0CfsECHhC2QOPy184gdHOxcRWap15e/K0RGic1Zl37tq6ySKLc2FQ==
   dependencies:
     "@trpc/client" "11.4.3"
     "@trpc/server" "11.4.3"


### PR DESCRIPTION
## Description

Related to this PR: https://github.com/opencrvs/opencrvs-core/pull/10387

Cc had outdated version of toolkit, which was causing errors like:

```
➜ opencrvs-countryconfig (develop) ✔ yarn test:compilation
yarn run v1.22.22
$ tsc --noEmit
src/api/notification/informantNotification.ts:59:27 - error TS2339: Property 'list' does not exist on type 'DecoratedProcedureRecord<{ transformer: true; errorShape: DefaultErrorShape; }, DecorateCreateRouterOptions<{ sync: MutationProcedure<{ input: void; output: void; meta: any; }>; get: QueryProcedure<{ input: void; output: { ...; }[]; meta: any; }>; set: MutationProcedure<...>; }>>'.

59   return client.locations.list.query()
```

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
