### PR TITLE
Add nested required field validator for dynamic field configs in child address fields

### DIFF
--- a/src/form/street-address-configuration.ts
+++ b/src/form/street-address-configuration.ts
@@ -4,8 +4,12 @@ import {
   not,
   field,
   AddressType,
-  FieldType
+  FieldType,
+  FieldConfig,
+  defineFormConditional,
+  errorMessages
 } from '@opencrvs/toolkit/events'
+import { type } from 'os'
 
 function isInternationalAddress() {
   return and(
@@ -19,6 +23,34 @@ function isDomesticAddress() {
     not(field('country').isUndefined()),
     field('addressType').isEqualTo(AddressType.DOMESTIC)
   )
+}
+
+export function getNestedFieldValidators(
+  fieldId: string,
+  fields: FieldConfig[]
+) {
+  return fields
+    .filter((x) => x.required)
+    .map((field) => ({
+      message:
+        typeof field.required === 'object'
+          ? field.required.message
+          : errorMessages.requiredField,
+
+      validator: defineFormConditional({
+        type: 'object',
+        properties: {
+          [fieldId]: {
+            type: 'object',
+            properties: {
+              [field.id]: {
+                minLength: 1
+              }
+            }
+          }
+        }
+      })
+    }))
 }
 
 export const defaultStreetAddressConfiguration = [
@@ -131,7 +163,13 @@ export const defaultStreetAddressConfiguration = [
       }
     ],
     parent: field('country'),
-    required: true,
+    required: {
+      message: {
+        id: 'field.address.state.label.required',
+        description: 'State required message',
+        defaultMessage: 'State is required'
+      }
+    },
     label: {
       id: 'field.address.state.label',
       defaultMessage: 'State',
@@ -148,7 +186,13 @@ export const defaultStreetAddressConfiguration = [
         conditional: isInternationalAddress()
       }
     ],
-    required: true,
+    required: {
+      message: {
+        id: 'field.address.district2.label.required',
+        description: 'District2 required message',
+        defaultMessage: 'District is required'
+      }
+    },
     label: {
       id: 'field.address.district2.label',
       defaultMessage: 'District',

--- a/src/form/v2/birth/forms/pages/child.ts
+++ b/src/form/v2/birth/forms/pages/child.ts
@@ -30,7 +30,10 @@ import {
   invalidNameValidator,
   MAX_NAME_LENGTH
 } from '@countryconfig/form/v2/birth/validators'
-import { defaultStreetAddressConfiguration } from '@countryconfig/form/street-address-configuration'
+import {
+  defaultStreetAddressConfiguration,
+  getNestedFieldValidators
+} from '@countryconfig/form/street-address-configuration'
 
 const GenderTypes = {
   MALE: 'male',
@@ -327,7 +330,11 @@ export const child = defineFormPage({
           validator: field(
             'child.address.privateHome'
           ).isValidAdministrativeLeafLevel()
-        }
+        },
+        ...getNestedFieldValidators(
+          'child.address.privateHome',
+          defaultStreetAddressConfiguration
+        )
       ],
       defaultValue: {
         country: 'FAR',
@@ -364,7 +371,11 @@ export const child = defineFormPage({
           validator: field(
             'child.address.other'
           ).isValidAdministrativeLeafLevel()
-        }
+        },
+        ...getNestedFieldValidators(
+          'child.address.other',
+          defaultStreetAddressConfiguration
+        )
       ],
       defaultValue: {
         country: 'FAR',

--- a/src/form/v2/birth/forms/pages/father.ts
+++ b/src/form/v2/birth/forms/pages/father.ts
@@ -35,7 +35,10 @@ import {
   yesNoRadioOptions,
   YesNoTypes
 } from '../../../person'
-import { defaultStreetAddressConfiguration } from '@countryconfig/form/street-address-configuration'
+import {
+  defaultStreetAddressConfiguration,
+  getNestedFieldValidators
+} from '@countryconfig/form/street-address-configuration'
 
 export const requireFatherDetails = or(
   field('father.detailsNotAvailable').isFalsy(),
@@ -397,7 +400,11 @@ export const father = defineFormPage({
             id: 'error.invalidInput'
           },
           validator: field('father.address').isValidAdministrativeLeafLevel()
-        }
+        },
+        ...getNestedFieldValidators(
+          'father.address',
+          defaultStreetAddressConfiguration
+        )
       ],
       defaultValue: {
         country: 'FAR',

--- a/src/form/v2/birth/forms/pages/informant.ts
+++ b/src/form/v2/birth/forms/pages/informant.ts
@@ -29,7 +29,10 @@ import {
   nationalIdValidator
 } from '@countryconfig/form/v2/birth/validators'
 import { IdType, idTypeOptions } from '../../../person'
-import { defaultStreetAddressConfiguration } from '@countryconfig/form/street-address-configuration'
+import {
+  defaultStreetAddressConfiguration,
+  getNestedFieldValidators
+} from '@countryconfig/form/street-address-configuration'
 
 export const InformantType = {
   MOTHER: 'MOTHER',
@@ -411,7 +414,11 @@ export const informant = defineFormPage({
             id: 'error.invalidInput'
           },
           validator: field('informant.address').isValidAdministrativeLeafLevel()
-        }
+        },
+        ...getNestedFieldValidators(
+          'informant.address',
+          defaultStreetAddressConfiguration
+        )
       ],
       defaultValue: {
         country: 'FAR',

--- a/src/form/v2/birth/forms/pages/mother.ts
+++ b/src/form/v2/birth/forms/pages/mother.ts
@@ -32,7 +32,10 @@ import {
   educationalAttainmentOptions,
   maritalStatusOptions
 } from '../../../../common/select-options'
-import { defaultStreetAddressConfiguration } from '@countryconfig/form/street-address-configuration'
+import {
+  defaultStreetAddressConfiguration,
+  getNestedFieldValidators
+} from '@countryconfig/form/street-address-configuration'
 
 export const requireMotherDetails = or(
   field('mother.detailsNotAvailable').isFalsy(),
@@ -361,7 +364,11 @@ export const mother = defineFormPage({
             id: 'error.invalidInput'
           },
           validator: field('mother.address').isValidAdministrativeLeafLevel()
-        }
+        },
+        ...getNestedFieldValidators(
+          'mother.address',
+          defaultStreetAddressConfiguration
+        )
       ],
       defaultValue: {
         country: 'FAR',

--- a/src/form/v2/death/forms/pages/deceased.ts
+++ b/src/form/v2/death/forms/pages/deceased.ts
@@ -33,7 +33,10 @@ import {
   idTypeOptions,
   maritalStatusOptions
 } from '@countryconfig/form/v2/person'
-import { defaultStreetAddressConfiguration } from '@countryconfig/form/street-address-configuration'
+import {
+  defaultStreetAddressConfiguration,
+  getNestedFieldValidators
+} from '@countryconfig/form/street-address-configuration'
 
 const GenderTypes = {
   MALE: 'male',
@@ -300,7 +303,11 @@ export const deceased = defineFormPage({
             id: 'error.invalidInput'
           },
           validator: field('deceased.address').isValidAdministrativeLeafLevel()
-        }
+        },
+        ...getNestedFieldValidators(
+          'deceased.address',
+          defaultStreetAddressConfiguration
+        )
       ],
       defaultValue: {
         country: 'FAR',

--- a/src/form/v2/death/forms/pages/eventDetails.ts
+++ b/src/form/v2/death/forms/pages/eventDetails.ts
@@ -24,7 +24,10 @@ import {
 
 import { createSelectOptions, emptyMessage } from '@countryconfig/form/v2/utils'
 import { applicationConfig } from '@countryconfig/api/application/application-config'
-import { defaultStreetAddressConfiguration } from '@countryconfig/form/street-address-configuration'
+import {
+  defaultStreetAddressConfiguration,
+  getNestedFieldValidators
+} from '@countryconfig/form/street-address-configuration'
 
 export const MannerDeathType = {
   MANNER_NATURAL: 'MANNER_NATURAL',
@@ -333,7 +336,11 @@ export const eventDetails = defineFormPage({
           validator: field(
             'eventDetails.deathLocationOther'
           ).isValidAdministrativeLeafLevel()
-        }
+        },
+        ...getNestedFieldValidators(
+          'eventDetails.deathLocationOther',
+          defaultStreetAddressConfiguration
+        )
       ],
       defaultValue: {
         country: 'FAR',

--- a/src/form/v2/death/forms/pages/informant.ts
+++ b/src/form/v2/death/forms/pages/informant.ts
@@ -34,7 +34,10 @@ import {
   yesNoRadioOptions,
   YesNoTypes
 } from '../../../person'
-import { defaultStreetAddressConfiguration } from '@countryconfig/form/street-address-configuration'
+import {
+  defaultStreetAddressConfiguration,
+  getNestedFieldValidators
+} from '@countryconfig/form/street-address-configuration'
 
 export const InformantType = {
   SPOUSE: 'SPOUSE',
@@ -446,7 +449,11 @@ export const informant = defineFormPage({
             id: 'error.invalidInput'
           },
           validator: field('informant.address').isValidAdministrativeLeafLevel()
-        }
+        },
+        ...getNestedFieldValidators(
+          'informant.address',
+          defaultStreetAddressConfiguration
+        )
       ],
       defaultValue: {
         country: 'FAR',

--- a/src/form/v2/death/forms/pages/spouse.ts
+++ b/src/form/v2/death/forms/pages/spouse.ts
@@ -34,7 +34,10 @@ import {
   YesNoTypes
 } from '../../../person'
 import { InformantType } from './informant'
-import { defaultStreetAddressConfiguration } from '@countryconfig/form/street-address-configuration'
+import {
+  defaultStreetAddressConfiguration,
+  getNestedFieldValidators
+} from '@countryconfig/form/street-address-configuration'
 
 export const requireSpouseDetails = or(
   field('spouse.detailsNotAvailable').isFalsy(),
@@ -381,7 +384,11 @@ export const spouse = defineFormPage({
             id: 'error.invalidInput'
           },
           validator: field('spouse.address').isValidAdministrativeLeafLevel()
-        }
+        },
+        ...getNestedFieldValidators(
+          'spouse.address',
+          defaultStreetAddressConfiguration
+        )
       ],
       defaultValue: {
         country: 'FAR',


### PR DESCRIPTION
issue: https://github.com/opencrvs/opencrvs-core/issues/10547

# Nested Field Validation

Some field components (for example, Address) encapsulate their own nested fields within the parent field configuration. By design, the required property defined on these nested fields is not automatically propagated to the core validation layer, since validation runs only against the top-level FieldConfig.

To address this limitation, we provide a custom helper function that:

- Accepts the list of nested field configurations.
- Extracts any fields marked with required.
- Generates the appropriate validation rules for these nested fields.
- Appends those rules to the parent field’s validation array so they are enforced at the form level.

This ensures that constraints defined inside encapsulated field components (e.g., street address line inside an Address field) are properly reflected in the overall form validation.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
