### PR TITLE
fix: use correct value for place of death in summary

### DIFF
--- a/src/form/v2/death/index.ts
+++ b/src/form/v2/death/index.ts
@@ -121,7 +121,7 @@ export const deathEvent = defineConfig({
         ]
       },
       {
-        fieldId: 'deceased.address',
+        fieldId: 'eventDetails.deathLocationOther',
         emptyValueMessage: {
           defaultMessage: 'No place of death',
           description:


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/issues/10562
Use correct value for summary field

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
