### PR TITLE
fix: Disable build arm images on tag

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: ${{ 
-          ((github.ref_type == 'tag' || inputs.build_arm == true) && fromJSON('["ubuntu-24.04", "ubuntu-24.04-arm"]')) || 
+          (inputs.build_arm == true && fromJSON('["ubuntu-24.04", "ubuntu-24.04-arm"]')) || 
           fromJSON('["ubuntu-24.04"]') 
           }}
     outputs:
@@ -90,7 +90,7 @@ jobs:
       - name: Create and push multi-arch manifest
         env:
           BRANCH_NAME: ${{ inputs.branch_name || github.ref_name }}
-          BUILD_ARM: ${{ github.ref_type == 'tag' || inputs.build_arm == true }}
+          BUILD_ARM: ${{ inputs.build_arm == true }}
         run: |
           TAG="${{ needs.build.outputs.version_common }}"
           REPO="${{ secrets.DOCKERHUB_ACCOUNT}}/${{ secrets.DOCKERHUB_REPO }}"


### PR DESCRIPTION
## Description

We got multiple reports from countries about issues building ARM images on private github repositories.
This PR aims to disable ARM images build unless manually triggered.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
