### PR TITLE
bug fix: street level address validation

### DIFF
--- a/src/form/street-address-configuration.ts
+++ b/src/form/street-address-configuration.ts
@@ -9,7 +9,6 @@ import {
   defineFormConditional,
   errorMessages
 } from '@opencrvs/toolkit/events'
-import { type } from 'os'
 
 function isInternationalAddress() {
   return and(
@@ -43,12 +42,20 @@ export function getNestedFieldValidators(
           [fieldId]: {
             type: 'object',
             properties: {
-              [field.id]: {
-                minLength: 1
+              streetLevelDetails: {
+                type: 'object',
+                properties: {
+                  [field.id]: {
+                    minLength: 1
+                  }
+                },
+                required: [field.id]
               }
-            }
+            },
+            required: ['streetLevelDetails']
           }
-        }
+        },
+        required: [fieldId]
       })
     }))
 }


### PR DESCRIPTION
## Description

issue: https://github.com/opencrvs/opencrvs-core/issues/10547#issuecomment-3377138071

<img width="724" height="819" alt="Screenshot 2025-10-08 at 3 46 25 PM" src="https://github.com/user-attachments/assets/44cf6a61-ac7c-4bdc-82f7-52c91750db96" />

Making sure when `addressType` is `INTERNATIONAL`, all the required `streetLevelAddress` validation are checked properly.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
