### PR TITLE
fix: events url in reindex job

### DIFF
--- a/.github/workflows/reindex.yml
+++ b/.github/workflows/reindex.yml
@@ -60,7 +60,6 @@ jobs:
               -w /workspace \
               --network opencrvs_overlay_net \
               -e 'AUTH_URL=http://auth:4040/' \
-              -e 'EVENTS_URL=http://gateway:7070/events/reindex' \
+              -e 'EVENTS_URL=http://gateway:7070/events' \
               alpine \
               sh -c 'apk add --no-cache curl jq && sh reindex.sh'"
-


### PR DESCRIPTION
## Description

Reindex job is failing with: `"Error for request: 'POST /reindex/events/reindex'. Error: 'Not found'"` because of extra /reindex in events url in the reindex job.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
