### PR TITLE
fix: Add APM server environment variable to events service

### DIFF
--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -692,6 +692,7 @@ services:
       - jwt-public-key.{{ts}}
     environment:
       - NODE_ENV=production
+      - APN_SERVICE_URL=http://apm-server:8200
       - EVENTS_MONGO_URL=mongodb://events:${EVENTS_MONGODB_PASSWORD}@mongo1/events?replicaSet=rs0
       - USER_MGNT_MONGO_URL=mongodb://user-mgnt:${USER_MGNT_MONGODB_PASSWORD}@mongo1/user-mgnt?replicaSet=rs0
       - ES_URL=http://search-user:${ROTATING_SEARCH_ELASTIC_PASSWORD}@elasticsearch:9200


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

See related issue: https://github.com/opencrvs/opencrvs-core/issues/10705


## Testing

Deployment workflow: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/18408617048/job/52454649863

Kibana URL: https://kibana.v19-beta-staging.opencrvs.dev/app/apm/services?comparisonEnabled=true&environment=ENVIRONMENT_ALL&rangeFrom=now-15h&rangeTo=now&offset=1d
<img width="1638" height="283" alt="image" src="https://github.com/user-attachments/assets/c8b3cbc3-fbdd-4092-9f4b-5c0412a159b7" />

Results validation in Kibana: 


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
