### PR TITLE
fix: Don't restart events and metabase services after data cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 ### Bug fixes
 
 - Allow non-interactive upgrades with apt [#10204](https://github.com/opencrvs/opencrvs-core/issues/10204)
+- Don't restart events service after data cleanup [#10704](https://github.com/opencrvs/opencrvs-core/issues/10704)
+
 
 ## 1.8.1
 

--- a/infrastructure/clear-all-data.sh
+++ b/infrastructure/clear-all-data.sh
@@ -151,12 +151,4 @@ echo "🚀 Reinitializing Postgres with on-deploy.sh..."
 
 docker service update --force opencrvs_postgres-on-update
 
-# Restart the metabase service
-#-----------------------------
-docker service scale opencrvs_dashboards=0
-docker service scale opencrvs_dashboards=1
-
-# Restart events service
-#-----------------------------
-docker service scale opencrvs_events=0
-docker service scale opencrvs_events=1
+echo "✅ All data cleared."


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/10704

This PR aims to sync changes committed into Farajaland and missed from Country config template.
Actual issue was already addressed by @cibelius:
- https://github.com/opencrvs/opencrvs-farajaland/commit/3aa1374e3fc34ab950be904157ce8eeea1c16521
- https://github.com/opencrvs/opencrvs-farajaland/commit/25eb001b590d20539f66e2e744e2f9a39a8f943f

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [x] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
