### PR TITLE
Ensure docker daemon does not depend on cryptfs logic on workers

### DIFF
--- a/infrastructure/server-setup/playbook.yml
+++ b/infrastructure/server-setup/playbook.yml
@@ -87,14 +87,6 @@
             - docker
       tags:
         - docker
-    
-    - include_tasks:
-        file: tasks/override-docker-startup.yml
-        apply:
-          tags: 
-            - docker
-      tags: 
-        - docker
 
     - include_tasks:
         file: tasks/deployment-user.yml
@@ -171,6 +163,13 @@
   become_method: sudo
   tasks:
     - include_tasks:
+        file: tasks/override-docker-startup.yml
+        apply:
+          tags:
+            - docker
+      tags:
+        - docker
+    - include_tasks:
         file: tasks/elasticsearch.yml
         apply:
           tags:
@@ -185,5 +184,19 @@
             - traefik
       tags:
         - traefik
+
+# Ensure incorrectly created override of docker daemon (1.9 beta) is removed on workers
+- hosts: docker-workers
+  become: yes
+  become_method: sudo
+  tasks:
+    - name: Remove docker service override directory
+      file:
+        path: /etc/systemd/system/docker.service.d
+        state: absent
+
+    - name: Reload systemd daemon to apply changes
+      systemd:
+        daemon_reload: yes
 
 - import_playbook: backups.yml


### PR DESCRIPTION
Data directories and cryptfs should only exist on manager node.

### Root cause

Docker service had been made dependant on CryptFS both in manager and worker machines. Worker machines do not hold any data, meaning they do not have cryptfs either. Event the shell scripts required to create the encryption do not exist on these machines.


### Fix

The logic is now so the dependency is only made between docker and cryptfs on manager nodes. I also made it so if this dependency had been created for a machine earlier, it is now removed.


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
