### PR TITLE
fix: Place of death in advanced search

### DIFF
--- a/src/form/v2/death/advancedSearch.ts
+++ b/src/form/v2/death/advancedSearch.ts
@@ -9,8 +9,44 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { AdvancedSearchConfig, event, field } from '@opencrvs/toolkit/events'
-import { placeOfDeathOptions } from './forms/pages/eventDetails'
+import {
+  AdvancedSearchConfig,
+  ConditionalType,
+  event,
+  field,
+  TranslationConfig
+} from '@opencrvs/toolkit/events'
+import { createSelectOptions } from '../utils'
+
+const PlaceOfDeath = {
+  HEALTH_FACILITY: 'HEALTH_FACILITY',
+  DECEASED_USUAL_RESIDENCE: 'DECEASED_USUAL_RESIDENCE',
+  OTHER: 'OTHER'
+} as const
+
+const placeOfDeathMessageDescriptors = {
+  HEALTH_FACILITY: {
+    defaultMessage: 'Health Institution',
+    description: 'Select item for Health Institution',
+    id: 'form.field.label.healthInstitution'
+  },
+  DECEASED_USUAL_RESIDENCE: {
+    defaultMessage: 'Residential address',
+    description: 'Select item for Private Home',
+    id: 'form.field.label.privateHome'
+  },
+  OTHER: {
+    defaultMessage: 'Other',
+    description: 'Select item for Other location',
+    id: 'form.field.label.otherInstitution'
+  }
+} satisfies Record<keyof typeof PlaceOfDeath, TranslationConfig>
+
+const placeOfDeathOptions = createSelectOptions(
+  PlaceOfDeath,
+  placeOfDeathMessageDescriptors
+)
+
 const deceasedPrefix = {
   id: 'death.search.criteria.label.prefix.deceased',
   defaultMessage: "Deceased's",
@@ -66,6 +102,16 @@ export const advancedSearchDeath = [
       }).exact(),
       field('eventDetails.deathLocation', {
         searchCriteriaLabelPrefix: deceasedPrefix
+      }).exact(),
+      field('deceased.address', {
+        conditionals: [
+          {
+            type: ConditionalType.SHOW,
+            conditional: field('eventDetails.placeOfDeath').isEqualTo(
+              PlaceOfDeath.DECEASED_USUAL_RESIDENCE
+            )
+          }
+        ]
       }).exact(),
       field('eventDetails.deathLocationOther', {}).exact()
     ]

--- a/src/form/v2/death/forms/pages/eventDetails.ts
+++ b/src/form/v2/death/forms/pages/eventDetails.ts
@@ -132,7 +132,7 @@ const placeOfDeathMessageDescriptors = {
   }
 } satisfies Record<keyof typeof PlaceOfDeath, TranslationConfig>
 
-export const placeOfDeathOptions = createSelectOptions(
+const placeOfDeathOptions = createSelectOptions(
   PlaceOfDeath,
   placeOfDeathMessageDescriptors
 )


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

[Farajaland PR](https://github.com/opencrvs/opencrvs-farajaland/pull/1766)
## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
