### PR TITLE
Remove all references and configuration to make an environment V2 from country config

### DIFF
--- a/src/client-config.js
+++ b/src/client-config.js
@@ -12,42 +12,36 @@
 /**
  * When running application in slow network condition (reproducible using 3G), the client-config.js might be loaded twice.
  * This results to issues like `Uncaught SyntaxError: "identifier scheme has already been declared at (client-config.js:1:1")`.
- * 
+ *
  * On high level, refreshing the browser window requests new document page. The document page includes script tag to load client-config.js.
  * If the network is slow, the browser might start loading and executing client-config.js again before the previous one is torn down, causing the error.
- * 
+ *
  */
 ;(function initClientConfig() {
-
-window.config = {
-  API_GATEWAY_URL: 'http://localhost:7070/',
-  CONFIG_API_URL: 'http://localhost:2021',
-  LOGIN_URL: 'http://localhost:3020',
-  AUTH_URL: 'http://localhost:7070/auth/',
-  MINIO_BUCKET: 'ocrvs',
-  MINIO_URL: 'http://localhost:3535/ocrvs/',
-  MINIO_BASE_URL: 'http://localhost:3535', // URL without path/bucket information, used for file uploads, v2
-  COUNTRY_CONFIG_URL: 'http://localhost:3040',
-  // Country code in uppercase ALPHA-3 format
-  COUNTRY: 'FAR',
-  LANGUAGES: 'en,fr',
-  SENTRY: '',
-  DASHBOARDS: [
-    {
-      id: 'leaderboards',
-      title: {
-        id: 'navigation.leaderboards',
-        defaultMessage: 'Development dashboard',
-        description: 'Menu item for development dashboard'
-      },
-      url: 'http://localhost:3040/ping',
-    }
-  ],
-  // NOTE: This is not valid javascript until replaced during build time.
-  // IIFE just reveals it.
-  FEATURES: {
-    // The V2_EVENTS variable is passed down from src/index.ts:309
-    V2_EVENTS: {{ V2_EVENTS }}
+  window.config = {
+    API_GATEWAY_URL: 'http://localhost:7070/',
+    CONFIG_API_URL: 'http://localhost:2021',
+    LOGIN_URL: 'http://localhost:3020',
+    AUTH_URL: 'http://localhost:7070/auth/',
+    MINIO_BUCKET: 'ocrvs',
+    MINIO_URL: 'http://localhost:3535/ocrvs/',
+    MINIO_BASE_URL: 'http://localhost:3535', // URL without path/bucket information, used for file uploads, v2
+    COUNTRY_CONFIG_URL: 'http://localhost:3040',
+    // Country code in uppercase ALPHA-3 format
+    COUNTRY: 'FAR',
+    LANGUAGES: 'en,fr',
+    SENTRY: '',
+    DASHBOARDS: [
+      {
+        id: 'leaderboards',
+        title: {
+          id: 'navigation.leaderboards',
+          defaultMessage: 'Development dashboard',
+          description: 'Menu item for development dashboard'
+        },
+        url: 'http://localhost:3040/ping'
+      }
+    ],
+    FEATURES: {}
   }
-}
 })()

--- a/src/client-config.prod.js
+++ b/src/client-config.prod.js
@@ -12,10 +12,10 @@
 /**
  * When running application in slow network condition (reproducible using 3G), the client-config.js might be loaded twice.
  * This results to issues like `Uncaught SyntaxError: "identifier scheme has already been declared at (client-config.js:1:1")`.
- * 
+ *
  * On high level, refreshing the browser window requests new document page. The document page includes script tag to load client-config.js.
  * If the network is slow, the browser might start loading and executing client-config.js again before the previous one is torn down, causing the error.
- * 
+ *
  */
 ;(function initClientConfig() {
   const scheme = window.location.protocol // "http:" or "https:"
@@ -66,9 +66,6 @@
     ],
     // NOTE: This is not valid javascript until replaced during build time.
     // IIFE just reveals it.
-    FEATURES: {
-      //  The V2_EVENTS variable is passed down from src/index.ts:309
-      V2_EVENTS: {{ V2_EVENTS }}
-    }
+    FEATURES: {}
   }
 })()

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,5 +31,4 @@ export const CHECK_INVALID_TOKEN = env.CHECK_INVALID_TOKEN
 
 export const PRODUCTION = env.isProd
 export const QA_ENV = env.QA_ENV
-export const V2_EVENTS = env.V2_EVENTS
 export const ANALYTICS_DATABASE_URL = env.ANALYTICS_DATABASE_URL

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -31,7 +31,6 @@ export const env = cleanEnv(process.env, {
     devDefault: 'http://localhost:5050/confirm/registration'
   }),
   QA_ENV: bool({ default: false }),
-  V2_EVENTS: bool({ default: false }),
   ANALYTICS_DATABASE_URL: url({
     devDefault:
       'postgres://events_analytics:analytics_password@localhost:5432/events',

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ require('dotenv').config()
 
 import StreamArray from 'stream-json/streamers/StreamArray'
 import path from 'path'
-import Handlebars from 'handlebars'
 import * as Hapi from '@hapi/hapi'
 import * as Pino from 'hapi-pino'
 import * as JWT from 'hapi-auth-jwt2'
@@ -25,7 +24,6 @@ import {
   DOMAIN,
   LOGIN_URL,
   SENTRY_DSN,
-  V2_EVENTS,
   COUNTRY_CONFIG_HOST,
   COUNTRY_CONFIG_PORT,
   CHECK_INVALID_TOKEN,
@@ -318,11 +316,7 @@ export async function createServer() {
           ? '/client-config.prod.js'
           : '/client-config.js'
 
-      const template = Handlebars.compile(
-        readFileSync(join(__dirname, file), 'utf8')
-      )
-      const result = template({ V2_EVENTS })
-      return h.response(result).type('application/javascript')
+      return h.file(join(__dirname, file))
     },
     options: {
       auth: false,


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

issue: https://github.com/opencrvs/opencrvs-core/issues/10707
core pr: https://github.com/opencrvs/opencrvs-core/pull/10763
farajaland pr: https://github.com/opencrvs/opencrvs-farajaland/pull/1768

## Description

Remove all references and configuration to make an environment V2 from country config

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
