### PR TITLE
fix: clear-all-data script fixes

### DIFF
--- a/infrastructure/clear-all-data.sh
+++ b/infrastructure/clear-all-data.sh
@@ -140,7 +140,7 @@ docker run --rm --network=$NETWORK  \
   -e POSTGRES_DB="${POSTGRES_DB}" \
   -e EVENTS_MIGRATOR_ROLE="${EVENTS_MIGRATOR_ROLE}" \
   -e EVENTS_APP_ROLE="${EVENTS_APP_ROLE}" \
-  -e ANALYTICS_POSTGRES_USER="${ANALYTICS_POSTGRES_USER}" \
+  -e ANALYTICS_POSTGRES_ROLE="${ANALYTICS_POSTGRES_ROLE}" \
   -e ANALYTICS_POSTGRES_DB="${ANALYTICS_POSTGRES_DB}" \
   postgres:17.6 bash -c '
 psql -h postgres -U "$POSTGRES_USER" -d postgres -v ON_ERROR_STOP=1 <<EOF
@@ -156,13 +156,5 @@ echo "✅ Database and roles dropped."
 echo "🚀 Reinitializing Postgres with on-deploy.sh..."
 
 docker service update --force opencrvs_postgres-on-update
-
-docker service scale opencrvs_dashboards=0
-docker service scale opencrvs_dashboards=1
-
-# Restart events service
-#-----------------------------
-docker service scale opencrvs_events=0
-docker service scale opencrvs_events=1
 
 echo "✅ All data cleared."


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description
Properly pass user name to cleanup script:
<img width="994" height="441" alt="image" src="https://github.com/user-attachments/assets/aef46222-8c7d-4e4f-a8cc-f4e052d4252c" />


## Testing

Script was executed manually on Farajaland e2e:
```
root@farajaland-integration-e2e:/opt/opencrvs/infrastructure# ./clear-all-data.sh 1
MongoDB shell version v4.4.29
connecting to: mongodb://mongo1:27017/hearth-dev?authSource=admin&compressors=disabled&gssapiServiceName=mongodb&replicaSet=rs0
Implicit session: session { "id" : UUID("467f4e1c-a06a-4c2f-8f99-f396c8bdbf84") }
MongoDB server version: 4.4.29
{
        "ok" : 1,
        "$clusterTime" : {
                "clusterTime" : Timestamp(1760710852, 1),
                "signature" : {
                        "hash" : BinData(0,"qTNst1islonCc27CLpDKiPQs6Bk="),
                        "keyId" : NumberLong("7532111153749557249")
                }
        },
        "operationTime" : Timestamp(1760710852, 1)
}
MongoDB shell version v4.4.29
connecting to: mongodb://mongo1:27017/events?authSource=admin&compressors=disabled&gssapiServiceName=mongodb&replicaSet=rs0
Implicit session: session { "id" : UUID("ecef2440-338c-48f5-b68d-d374256a5fe0") }
MongoDB server version: 4.4.29
{
        "ok" : 1,
        "$clusterTime" : {
                "clusterTime" : Timestamp(1760710852, 1),
                "signature" : {
                        "hash" : BinData(0,"qTNst1islonCc27CLpDKiPQs6Bk="),
                        "keyId" : NumberLong("7532111153749557249")
                }
        },
        "operationTime" : Timestamp(1760710852, 1)
}
MongoDB shell version v4.4.29
connecting to: mongodb://mongo1:27017/openhim-dev?authSource=admin&compressors=disabled&gssapiServiceName=mongodb&replicaSet=rs0
Implicit session: session { "id" : UUID("8a75dfe6-1ec3-40c7-891e-7c039cab9098") }
MongoDB server version: 4.4.29
{
        "ok" : 1,
        "$clusterTime" : {
                "clusterTime" : Timestamp(1760710852, 1),
                "signature" : {
                        "hash" : BinData(0,"qTNst1islonCc27CLpDKiPQs6Bk="),
                        "keyId" : NumberLong("7532111153749557249")
                }
        },
        "operationTime" : Timestamp(1760710852, 1)
}
MongoDB shell version v4.4.29
connecting to: mongodb://mongo1:27017/user-mgnt?authSource=admin&compressors=disabled&gssapiServiceName=mongodb&replicaSet=rs0
Implicit session: session { "id" : UUID("c9338898-1ea4-4cbd-aa24-67ddc8f585e6") }
MongoDB server version: 4.4.29
{
        "ok" : 1,
        "$clusterTime" : {
                "clusterTime" : Timestamp(1760710852, 1),
                "signature" : {
                        "hash" : BinData(0,"qTNst1islonCc27CLpDKiPQs6Bk="),
                        "keyId" : NumberLong("7532111153749557249")
                }
        },
        "operationTime" : Timestamp(1760710852, 1)
}
MongoDB shell version v4.4.29
connecting to: mongodb://mongo1:27017/application-config?authSource=admin&compressors=disabled&gssapiServiceName=mongodb&replicaSet=rs0
Implicit session: session { "id" : UUID("710da858-132c-4ccd-9b83-4218a97a486b") }
MongoDB server version: 4.4.29
{
        "ok" : 1,
        "$clusterTime" : {
                "clusterTime" : Timestamp(1760710852, 1),
                "signature" : {
                        "hash" : BinData(0,"qTNst1islonCc27CLpDKiPQs6Bk="),
                        "keyId" : NumberLong("7532111153749557249")
                }
        },
        "operationTime" : Timestamp(1760710852, 1)
}
MongoDB shell version v4.4.29
connecting to: mongodb://mongo1:27017/metrics?authSource=admin&compressors=disabled&gssapiServiceName=mongodb&replicaSet=rs0
Implicit session: session { "id" : UUID("9e30c512-ef6e-4de3-b795-01f54d971aba") }
MongoDB server version: 4.4.29
{
        "ok" : 1,
        "$clusterTime" : {
                "clusterTime" : Timestamp(1760710852, 1),
                "signature" : {
                        "hash" : BinData(0,"qTNst1islonCc27CLpDKiPQs6Bk="),
                        "keyId" : NumberLong("7532111153749557249")
                }
        },
        "operationTime" : Timestamp(1760710852, 1)
}
MongoDB shell version v4.4.29
connecting to: mongodb://mongo1:27017/performance?authSource=admin&compressors=disabled&gssapiServiceName=mongodb&replicaSet=rs0
Implicit session: session { "id" : UUID("9dcb460a-b75f-4566-ba10-a07fa0a3b3f0") }
MongoDB server version: 4.4.29
{
        "ok" : 1,
        "$clusterTime" : {
                "clusterTime" : Timestamp(1760710852, 1),
                "signature" : {
                        "hash" : BinData(0,"qTNst1islonCc27CLpDKiPQs6Bk="),
                        "keyId" : NumberLong("7532111153749557249")
                }
        },
        "operationTime" : Timestamp(1760710852, 1)
}
--------------------------
🧹 cleanup for indices from elastic:Kkiq6NArVM9JQfeg@elasticsearch:9200: .ds-metricbeat-8.14.3-2025.03.29-001094
ecs-logstash
.ds-metricbeat-8.16.4-2025.10.17-003774
elastalert_status_status
.ds-filebeat-8.16.4-2025.10.03-001436
.ds-filebeat-8.14.3-2025.03.27-000052
apm-7.17.22-metric
.monitoring-beats-7-2025.10.17
apm-7.17.22-error
--------------------------
Removing index .ds-metricbeat-8.14.3-2025.03.29-001094
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"index [.ds-metricbeat-8.14.3-2025.03.29-001094] is the write index for data stream [metricbeat-8.14.3] and cannot be deleted"}],"type":"illegal_argument_exception","reason":"index [.ds-metricbeat-8.14.3-2025.03.29-001094] is the write index for data stream [metricbeat-8.14.3] and cannot be deleted"},"status":400}Removing index ecs-logstash
{"acknowledged":true}Removing index .ds-metricbeat-8.16.4-2025.10.17-003774
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"index [.ds-metricbeat-8.16.4-2025.10.17-003774] is the write index for data stream [metricbeat-8.16.4] and cannot be deleted"}],"type":"illegal_argument_exception","reason":"index [.ds-metricbeat-8.16.4-2025.10.17-003774] is the write index for data stream [metricbeat-8.16.4] and cannot be deleted"},"status":400}Removing index elastalert_status_status
{"acknowledged":true}Removing index .ds-filebeat-8.16.4-2025.10.03-001436
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"index [.ds-filebeat-8.16.4-2025.10.03-001436] is the write index for data stream [filebeat-8.16.4] and cannot be deleted"}],"type":"illegal_argument_exception","reason":"index [.ds-filebeat-8.16.4-2025.10.03-001436] is the write index for data stream [filebeat-8.16.4] and cannot be deleted"},"status":400}Removing index .ds-filebeat-8.14.3-2025.03.27-000052
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"index [.ds-filebeat-8.14.3-2025.03.27-000052] is the write index for data stream [filebeat-8.14.3] and cannot be deleted"}],"type":"illegal_argument_exception","reason":"index [.ds-filebeat-8.14.3-2025.03.27-000052] is the write index for data stream [filebeat-8.14.3] and cannot be deleted"},"status":400}Removing index apm-7.17.22-metric
{"acknowledged":true}Removing index .monitoring-beats-7-2025.10.17
{"acknowledged":true}Removing index apm-7.17.22-error
{"acknowledged":true}Note: Unnecessary use of -X or --request, POST is already inferred.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 10.0.1.76...
* TCP_NODELAY set
* Connected to influxdb (10.0.1.76) port 8086 (#0)
> POST /query?db=ocrvs HTTP/1.1
> Host: influxdb:8086
> User-Agent: curl/7.59.0
> Accept: */*
> Content-Length: 35
> Content-Type: application/x-www-form-urlencoded
> 
} [35 bytes data]
* upload completely sent off: 35 out of 35 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json
< Request-Id: 85d6d4cd-ab64-11f0-800f-02420a000115
< X-Influxdb-Build: OSS
< X-Influxdb-Version: 1.8.10
< X-Request-Id: 85d6d4cd-ab64-11f0-800f-02420a000115
< Date: Fri, 17 Oct 2025 14:21:07 GMT
< Transfer-Encoding: chunked
< 
{ [44 bytes data]
100    68    0    33  100    35   5500   5833 --:--:-- --:--:-- --:--:-- 11333
* Connection #0 to host influxdb left intact
{"results":[{"statement_id":0}]}
Added `myminio` successfully.
Removed `myminio/ocrvs` successfully.
Bucket created successfully `myminio/ocrvs`.
🔁 Dropping database 'events' and roles...
DROP DATABASE
DROP DATABASE
NOTICE:  database "analytics" does not exist, skipping
DROP ROLE
DROP ROLE
DROP ROLE
✅ Database and roles dropped.
🚀 Reinitializing Postgres with on-deploy.sh...
opencrvs_postgres-on-update
overall progress: 1 out of 1 tasks 
1/1: running   [==================================================>] 
verify: Service opencrvs_postgres-on-update converged 
✅ All data cleared.
```

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
