### PR TITLE
fix: don't populate location as part of setup-analytics

### DIFF
--- a/infrastructure/postgres/setup-analytics.sh
+++ b/infrastructure/postgres/setup-analytics.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# NOTE!
+# This setup is ran before core migrations. Therefore you CAN NOT refer to the tables or data in core.
+
 # Configuration
 : "${POSTGRES_HOST:=localhost}"
 : "${POSTGRES_PORT:=5432}"


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
