### PR TITLE
Do 'Date of death must be after the deceased's birth date' validation only if dobUnknown is not checked

### DIFF
--- a/src/form/v2/death/forms/pages/eventDetails.ts
+++ b/src/form/v2/death/forms/pages/eventDetails.ts
@@ -168,9 +168,10 @@ export const eventDetails = defineFormPage({
               'This is the error message for date of death before date of birth',
             id: 'event.death.action.declare.form.section.event.field.date.error.beforeBirth'
           },
-          validator: field('eventDetails.date')
-            .isAfter()
-            .date(field('deceased.dob'))
+          validator: or(
+            field('eventDetails.date').isAfter().date(field('deceased.dob')),
+            field('deceased.dobUnknown').isEqualTo(true)
+          )
         }
       ],
       label: {


### PR DESCRIPTION
## Description

Resolve comment: https://github.com/opencrvs/opencrvs-core/issues/10527#issuecomment-3421899354

Do 'Date of death must be after the deceased's birth date' validation only if dobUnknown is not checked

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
