### PR TITLE
fix: Revert data collection storage from 30d to 2d

### DIFF
--- a/infrastructure/monitoring/metricbeat/metricbeat-rollover-policy.json
+++ b/infrastructure/monitoring/metricbeat/metricbeat-rollover-policy.json
@@ -1,48 +1,23 @@
 {
   "policy": {
-      "phases": {
-        "hot": {
-          "actions": {
-            "rollover": {
-              "max_size": "2GB",
-              "max_age": "1d"
-            },
-            "set_priority": {
-              "priority": 100
-            }
-          }
-        },
-        "warm": {
-          "min_age": "3d",
-          "actions": {
-            "allocate": {
-              "number_of_replicas": 0
-            },
-            "forcemerge": {
-              "max_num_segments": 1
-            },
-            "set_priority": {
-              "priority": 50
-            }
-          }
-        },
-        "cold": {
-          "min_age": "7d",
-          "actions": {
-            "allocate": {
-              "number_of_replicas": 0
-            },
-            "set_priority": {
-              "priority": 0
-            }
-          }
-        },
-        "delete": {
-          "min_age": "30d",
-          "actions": {
-            "delete": {}
+    "phases": {
+      "hot": {
+        "min_age": "0ms",
+        "actions": {
+          "rollover": {
+            "max_age": "3d",
+            "max_size": "200mb"
           }
         }
+      },
+      "delete": {
+        "min_age": "2d",
+        "actions": {
+          "delete": {
+            "delete_searchable_snapshot": true
+          }
+        }
+      }
     },
     "_meta": {
       "managed": true,


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Goal of this PR is to revert changes introduced by https://github.com/opencrvs/opencrvs-countryconfig/pull/1039

## Testing

Usage reported before fix deployment:
```
jamil@farajaland-dev:/data$ sudo du -h --max-depth=1 | sort -rh
48G	.
41G	./elasticsearch
674M	./mongo
185M	./minio
100M	./influxdb
71M	./postgres
140K	./traefik
32K	./vsexport
32K	./backups
28K	./sqlite
16K	./lost+found
8.0K	./secrets
4.0K	./wireguard
```

Deployment: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/19032563850/job/54349792255

Verified usage after depoyment: 
<img width="583" height="200" alt="image" src="https://github.com/user-attachments/assets/a1321b66-81d5-4af3-bed5-adef69db982b" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
