### PR TITLE
Upgrade traefik to 2.11

### DIFF
--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -11,7 +11,7 @@ services:
   # Note: these published port will override UFW rules as Docker manages it's own iptables
   # Only publish the exact ports that are required for OpenCRVS to work
   traefik:
-    image: 'traefik:v2.10'
+    image: 'traefik:v2.11'
     ports:
       - target: 80
         published: 80


### PR DESCRIPTION
Fixed Docker API version issue

Issue:
Traefik v2.10 supports Docker API v1.24. However, current Docker versions require using API v1.44+ 

This causes all routes to throw a 404 since Traefik cannot connect to Docker.

Traefik v2.11 uses the new API.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
