### PR TITLE
feat: configure tennis-club-membership to enable testing non-farajaland cases

### DIFF
--- a/src/form/tennis-club-membership.ts
+++ b/src/form/tennis-club-membership.ts
@@ -297,6 +297,10 @@ const TENNIS_CLUB_DECLARATION_FORM = defineDeclarationForm({
           },
           conditionals: [
             {
+              type: ConditionalType.SHOW,
+              conditional: field('recommender.none').isFalsy()
+            },
+            {
               type: ConditionalType.DISPLAY_ON_REVIEW,
               conditional: never()
             }
@@ -345,6 +349,66 @@ const TENNIS_CLUB_DECLARATION_FORM = defineDeclarationForm({
             defaultMessage: "Recommender's membership ID",
             description: 'This is the label for the field',
             id: 'event.tennis-club-membership.action.declare.form.section.recommender.field.id.label'
+          }
+        },
+        {
+          id: 'recommender2.id',
+          type: 'TEXT',
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('recommender.none').isFalsy()
+            }
+          ],
+          label: {
+            defaultMessage: "2nd recommender's membership ID",
+            description: 'This is the label for the field',
+            id: 'event.tennis-club-membership.action.declare.form.section.recommender2.field.id.label'
+          }
+        },
+        {
+          id: 'recommender3.id',
+          type: 'TEXT',
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('recommender.none').isFalsy()
+            }
+          ],
+          label: {
+            defaultMessage: "3rd recommender's membership ID",
+            description: 'This is the label for the field',
+            id: 'event.tennis-club-membership.action.declare.form.section.recommender3.field.id.label'
+          }
+        },
+        {
+          id: 'recommender4.id',
+          type: 'TEXT',
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('recommender.none').isFalsy()
+            }
+          ],
+          label: {
+            defaultMessage: "4th recommender's membership ID",
+            description: 'This is the label for the field',
+            id: 'event.tennis-club-membership.action.declare.form.section.recommender4.field.id.label'
+          }
+        },
+        {
+          id: 'recommender5.id',
+          type: 'TEXT',
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('recommender.none').isFalsy()
+            }
+          ],
+          label: {
+            defaultMessage: "5th recommender's membership ID",
+            description: 'This is the label for the field',
+            id: 'event.tennis-club-membership.action.declare.form.section.recommender5.field.id.label'
           }
         }
       ]
@@ -1118,7 +1182,29 @@ export const tennisClubMembershipEvent = defineConfig({
         description: 'Recommender details search field section title',
         id: 'event.tennis-club-membership.search.recommender'
       },
-      fields: [field('recommender.name').fuzzy()]
+      fields: [
+        field('recommender.name').fuzzy(),
+        {
+          fieldId: 'recommender.id',
+          fieldType: 'field',
+          type: FieldType.TEXT,
+          config: {
+            type: 'fuzzy',
+            searchFields: [
+              'recommender.id',
+              'recommender2.id',
+              'recommender3.id',
+              'recommender4.id',
+              'recommender5.id'
+            ]
+          },
+          label: {
+            defaultMessage: "Recommender's Id",
+            description: 'Recommender id search field title',
+            id: 'event.tennis-club-membership.search.recommender.id'
+          }
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

[Screencast from 2025-11-14 14-49-59.webm](https://github.com/user-attachments/assets/3e57ddc9-2b1c-4936-94b2-497378d67ca7)


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
