### PR TITLE
feat: add test notes field in custom action form

### DIFF
--- a/src/form/v2/birth/index.ts
+++ b/src/form/v2/birth/index.ts
@@ -240,11 +240,10 @@ export const birthEvent = defineConfig({
           type: 'TEXTAREA',
           required: true,
           label: {
-            defaultMessage: 'Reason for delayed registration',
-            description: 'This is the label for the field',
-            id: 'event.birth.action.declare.form.section.child.field.reason.label'
-          },
-          conditionals: []
+            defaultMessage: 'Notes',
+            description: 'This is the label for the field for a custom action',
+            id: 'event.birth.custom.action.approve.field.notes.label'
+          }
         }
       ],
       flags: [

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -25,6 +25,7 @@ advancedSearch.form.deceasedDetails,The title of Deceased details accordion,Dece
 advancedSearch.form.eventDetails,The title of event details accordion,Event details,Détails de l'évènement
 advancedSearch.form.fatherDetails,The title of Father details accordion,Father details,Information du père
 advancedSearch.form.informantDetails,The title informant details form,Informant details,information de l'informateur
+event.birth.custom.action.approve.field.notes.label,This is the label for the field for a custom action,Notes,Remarques
 advancedSearch.form.motherDetails,The title of Mother details accordion,Mother details,Information de la mère
 advancedSearch.form.placeOfRegistration,Label for input Place of registration,Place of registration,Lieu d'enregistrement
 advancedSearch.form.placeOfRegistrationHelperText,Helper text for input Place of registration,"Search for a province, district or registration office","Rechercher une province, un district ou un bureau d'enregistrement"


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
