### PR TITLE
Add recommender search example in tennis club collector form

### DIFF
--- a/src/form/tennis-club-membership.ts
+++ b/src/form/tennis-club-membership.ts
@@ -452,6 +452,14 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
             },
             {
               label: {
+                id: 'event.tennis-club-membership.action.certificate.form.section.requester.recommender.label',
+                defaultMessage: 'Print and issue to recommender',
+                description: 'This is the label for the field'
+              },
+              value: 'RECOMMENDER'
+            },
+            {
+              label: {
                 id: 'event.tennis-club-membership.action.certificate.form.section.requester.other.label',
                 defaultMessage: 'Print and issue someone else',
                 description: 'This is the label for the field'
@@ -467,6 +475,120 @@ const TENNIS_CLUB_MEMBERSHIP_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
               value: 'PRINT_IN_ADVANCE'
             }
           ]
+        },
+        {
+          id: 'collector.recommender.search',
+          type: FieldType.SEARCH,
+          label: {
+            defaultMessage: 'Registration Number of recommender',
+            description: 'This is the label for the field',
+            id: 'event.tennis-club-membership.action.declare.form.section.recommender.field.search.label'
+          },
+          configuration: {
+            query: {
+              type: 'or',
+              clauses: [
+                {
+                  'legalStatuses.REGISTERED.registrationNumber': {
+                    term: '{term}',
+                    type: 'exact'
+                  }
+                }
+              ]
+            },
+            limit: 10,
+            offset: 0,
+            validation: {
+              validator: defineConditional({
+                type: 'string',
+                pattern: '^[A-Za-z0-9]{12}$',
+                description: 'Must be alpha-numeric and 12 characters long'
+              }),
+              message: {
+                defaultMessage:
+                  'Invalid value: Must be alpha-numeric and 12 characters long',
+                description: 'Error message for invalid value',
+                id: 'tennis-club-membership.searchField.validation.invalid'
+              }
+            },
+            indicators: {
+              ok: {
+                defaultMessage: 'Recommender found',
+                description: 'OK button text',
+                id: 'tennis-club-membership.searchField.indicators.ok'
+              },
+              clearModal: {
+                title: {
+                  defaultMessage: 'Clear recommender?',
+                  description: 'Title for the clear confirmation modal',
+                  id: 'tennis-club-membership.searchField.indicators.clearModal.title'
+                },
+                description: {
+                  defaultMessage:
+                    'This will remove the details of the current recommender.',
+                  description: 'Description for the clear confirmation modal',
+                  id: 'tennis-club-membership.searchField.indicators.clearModal.description'
+                }
+              }
+            }
+          },
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('collector.requesterId').isEqualTo(
+                'RECOMMENDER'
+              )
+            }
+          ]
+        },
+        {
+          id: 'collector.recommender.name',
+          configuration: { maxLength: MAX_NAME_LENGTH },
+          type: FieldType.NAME,
+          required: true,
+          parent: field('collector.recommender.search'),
+          value: field('collector.recommender.search').getByPath([
+            'data',
+            'firstResult',
+            'declaration',
+            'applicant.name'
+          ]),
+          hideLabel: true,
+          label: {
+            defaultMessage: "Recommender's name",
+            description: 'This is the label for the field',
+            id: 'event.tennis-club-membership.action.declare.form.section.recommender.field.firstname.label'
+          },
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('collector.requesterId').isEqualTo(
+                'RECOMMENDER'
+              )
+            }
+          ]
+        },
+        {
+          id: 'collector.recommender.id',
+          type: 'TEXT',
+          required: true,
+          parent: field('collector.recommender.search'),
+          value: field('collector.recommender.search').get(
+            'data.firstResult.legalStatuses.REGISTERED.registrationNumber'
+          ),
+          conditionals: [
+            {
+              type: ConditionalType.SHOW,
+              conditional: field('collector.requesterId').isEqualTo(
+                'RECOMMENDER'
+              )
+            }
+          ],
+          label: {
+            defaultMessage: "Recommender's membership ID",
+            description: 'This is the label for the field',
+            id: 'event.tennis-club-membership.action.declare.form.section.recommender.field.id.label'
+          }
         },
         {
           id: 'collector.OTHER.idType',

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -1068,6 +1068,7 @@ event.tennis-club-membership.action.certificate.form.section.requester.informant
 event.tennis-club-membership.action.certificate.form.section.requester.label,This is the label for the field,Requester,Requester
 event.tennis-club-membership.action.certificate.form.section.requester.other.label,This is the label for the field,Print and issue someone else,Print and issue someone else
 event.tennis-club-membership.action.certificate.form.section.requester.printInAdvance.label,This is the label for the field,Print in advance,Imprimer à l'avance pour les signatures et la collecte
+event.tennis-club-membership.action.certificate.form.section.requester.recommender.label,This is the label for the field,Print and issue Recommender,Print and issue Recommender
 event.tennis-club-membership.action.certificate.form.section.who.title,This is the title of the section,Print certified copy,Imprimer une copie certifiée
 event.tennis-club-membership.action.collect-certificate.label,This is shown as the action name anywhere the user can trigger the action from,Print certificate,Imprimer le certificat
 event.tennis-club-membership.action.declare.form.label,This is what this form is referred as in the system,Tennis club membership application,Tennis club membership application


### PR DESCRIPTION
## Description

Population of fields from BRN search component is not working in the collector form.
This adds the fields so as to demonstrate the issue.

Linked to https://github.com/opencrvs/opencrvs-core/issues/11180

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
