### PR TITLE
"requireCompletionToContinue" in form page config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.9.3
+
+### New features
+
+- Introduced page-level `requireCompletionToContinue` in birth and death event config, to enforce full completion before moving to the next page, and updated navigation logic accordingly.
+
 ## 1.9.2
 
 ### New features
@@ -80,7 +86,6 @@
 ### Bug fixes
 
 - Remove special characters from role ids on generation [#10049](https://github.com/opencrvs/opencrvs-core/issues/10049)
-
 
 ## 1.7.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/countryconfig",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "OpenCRVS country configuration for reference data",
   "os": [
     "darwin",
@@ -69,7 +69,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/toolkit": "1.9.2",
+    "@opencrvs/toolkit": "1.9.3-rc.866b278",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",
     "@types/fhir": "^0.0.30",

--- a/src/form/v2/birth/forms/correctionForm/index.ts
+++ b/src/form/v2/birth/forms/correctionForm/index.ts
@@ -20,6 +20,7 @@ export const CORRECTION_FORM = defineActionForm({
     {
       id: 'details',
       type: PageTypes.enum.FORM,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.birth.action.correction.form.section.details.title',
         defaultMessage: 'Correction details',
@@ -119,6 +120,7 @@ export const CORRECTION_FORM = defineActionForm({
     {
       id: 'requester.identity.verify',
       type: PageTypes.enum.VERIFICATION,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.birth.action.correction.form.section.requester.identity.verify.title',
         defaultMessage: 'Verify ID',
@@ -165,6 +167,7 @@ export const CORRECTION_FORM = defineActionForm({
     {
       id: 'documents',
       type: PageTypes.enum.FORM,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.birth.action.correction.form.section.supporting-documents.title',
         defaultMessage: 'Upload supporting documents',
@@ -211,6 +214,7 @@ export const CORRECTION_FORM = defineActionForm({
     {
       id: 'fees',
       type: PageTypes.enum.FORM,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.birth.action.correction.form.section.fees.title',
         defaultMessage: 'Collect fees',

--- a/src/form/v2/birth/forms/printForm/index.ts
+++ b/src/form/v2/birth/forms/printForm/index.ts
@@ -33,6 +33,7 @@ export const BIRTH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
     {
       id: 'collector',
       type: PageTypes.enum.FORM,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.birth.action.certificate.form.section.who.title',
         defaultMessage: 'Certify record',
@@ -43,6 +44,7 @@ export const BIRTH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
     {
       id: 'collector.identity.verify',
       type: PageTypes.enum.VERIFICATION,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.birth.action.print.verifyIdentity',
         defaultMessage: 'Verify their identity',
@@ -88,6 +90,7 @@ export const BIRTH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
     {
       id: 'collector.collect.payment',
       type: PageTypes.enum.FORM,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.birth.action.print.collectPayment',
         defaultMessage: 'Collect Payment',

--- a/src/form/v2/death/forms/correctionForm/index.ts
+++ b/src/form/v2/death/forms/correctionForm/index.ts
@@ -20,6 +20,7 @@ export const DEATH_CORRECTION_FORM = defineActionForm({
     {
       id: 'details',
       type: PageTypes.enum.FORM,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.death.action.correction.form.section.details.title',
         defaultMessage: 'Correction details',
@@ -119,6 +120,7 @@ export const DEATH_CORRECTION_FORM = defineActionForm({
     {
       id: 'requester.identity.verify',
       type: PageTypes.enum.VERIFICATION,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.death.action.correction.form.section.requester.identity.verify.title',
         defaultMessage: 'Verify ID',
@@ -165,6 +167,7 @@ export const DEATH_CORRECTION_FORM = defineActionForm({
     {
       id: 'documents',
       type: PageTypes.enum.FORM,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.death.action.correction.form.section.supporting-documents.title',
         defaultMessage: 'Upload supporting documents',
@@ -211,6 +214,7 @@ export const DEATH_CORRECTION_FORM = defineActionForm({
     {
       id: 'fees',
       type: PageTypes.enum.FORM,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.death.action.correction.form.section.fees.title',
         defaultMessage: 'Collect fees',

--- a/src/form/v2/death/forms/printForm/index.ts
+++ b/src/form/v2/death/forms/printForm/index.ts
@@ -34,6 +34,7 @@ export const DEATH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
     {
       id: 'collector',
       type: PageTypes.enum.FORM,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.death.action.certificate.form.section.who.title',
         defaultMessage: 'Certify record',
@@ -44,6 +45,7 @@ export const DEATH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
     {
       id: 'collector.identity.verify',
       type: PageTypes.enum.VERIFICATION,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.death.action.print.verifyIdentity',
         defaultMessage: 'Verify their identity',
@@ -92,6 +94,7 @@ export const DEATH_CERTIFICATE_COLLECTOR_FORM = defineActionForm({
     {
       id: 'collector.collect.payment',
       type: PageTypes.enum.FORM,
+      requireCompletionToContinue: true,
       title: {
         id: 'event.birth.action.print.collectPayment',
         defaultMessage: 'Collect Payment',


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

https://github.com/opencrvs/opencrvs-core/issues/11213

Introduced form page level config - 'requireCompletionToContinue' to enforce full completion of the form page before moving to the next page

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
