### PR TITLE
placeOfEvent for birth and death event added

### DIFF
--- a/src/form/v2/birth/forms/pages/child.ts
+++ b/src/form/v2/birth/forms/pages/child.ts
@@ -392,6 +392,27 @@ export const child = defineFormPage({
       }
     },
     {
+      id: 'child.birthLocationId',
+      type: FieldType.ALPHA_HIDDEN,
+      required: false,
+      label: {
+        defaultMessage: 'Health Institution',
+        description: 'This is the label for the field',
+        id: 'event.birth.action.declare.form.section.child.field.birthLocation.label'
+      },
+      parent: [
+        field('child.placeOfBirth'),
+        field('child.birthLocation'),
+        field('child.birthLocation.privateHome'),
+        field('child.birthLocation.other')
+      ],
+      value: [
+        field('child.birthLocation'),
+        field('child.birthLocation.privateHome').get('administrativeArea'),
+        field('child.birthLocation.other').get('administrativeArea')
+      ]
+    },
+    {
       id: 'child.divider2',
       type: FieldType.DIVIDER,
       label: emptyMessage

--- a/src/form/v2/birth/index.ts
+++ b/src/form/v2/birth/index.ts
@@ -43,6 +43,7 @@ export const birthEvent = defineConfig({
     id: 'event.birth.label'
   },
   dateOfEvent: field('child.dob'),
+  placeOfEvent: field('child.birthLocationId'),
   title: {
     defaultMessage: '{child.name.firstname} {child.name.surname}',
     description: 'This is the title of the summary',

--- a/src/form/v2/death/forms/pages/eventDetails.ts
+++ b/src/form/v2/death/forms/pages/eventDetails.ts
@@ -364,6 +364,27 @@ export const eventDetails = defineFormPage({
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration
       }
+    },
+    {
+      id: 'eventDetails.deathLocationId',
+      type: FieldType.ALPHA_HIDDEN,
+      required: false,
+      label: {
+        defaultMessage: 'Health Institution',
+        description: 'This is the label for the field',
+        id: 'event.birth.action.declare.form.section.child.field.birthLocation.label'
+      },
+      parent: [
+        field('eventDetails.placeOfDeath'),
+        field('eventDetails.deathLocation'),
+        field('eventDetails.deathLocationOther'),
+        field('deceased.address')
+      ],
+      value: [
+        field('eventDetails.deathLocation'),
+        field('eventDetails.deathLocationOther').get('administrativeArea'),
+        field('deceased.address').get('administrativeArea')
+      ]
     }
   ]
 })

--- a/src/form/v2/death/index.ts
+++ b/src/form/v2/death/index.ts
@@ -41,6 +41,7 @@ export const deathEvent = defineConfig({
     id: 'event.death.label'
   },
   dateOfEvent: field('eventDetails.date'),
+  placeOfEvent: field('eventDetails.deathLocationId'),
   title: {
     defaultMessage: '{deceased.name.firstname} {deceased.name.surname}',
     description: 'This is the title of the summary',


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

https://github.com/opencrvs/opencrvs-core/issues/11427

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
