### PR TITLE
feat: Build shared assets image for countryconfig assets

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -77,12 +77,12 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_ACCOUNT}}/${{ secrets.DOCKERHUB_REPO }}:${{ steps.country_config.outputs.version }}
 
-      - name: Build and push metabase assets image
+      - name: Build and push assets image
         uses: docker/build-push-action@v6
         with:
           push: true
           context: .
-          file: ./Dockerfile.metabase.assets
+          file: ./Dockerfile.assets
           tags: |
             ${{ secrets.DOCKERHUB_ACCOUNT}}/${{ secrets.DOCKERHUB_REPO }}:${{ steps.country_config.outputs.version }}-assets
 

--- a/Dockerfile.assets
+++ b/Dockerfile.assets
@@ -1,0 +1,11 @@
+FROM alpine:3.20
+
+# Directory inside the assets image
+WORKDIR /assets
+
+# Copy assets
+COPY infrastructure/metabase /assets/metabase
+COPY infrastructure/postgres /assets/postgres
+
+RUN chmod +x /assets/metabase/*.sh \
+             /assets/postgres/*.sh

--- a/Dockerfile.metabase.assets
+++ b/Dockerfile.metabase.assets
@@ -1,9 +1,0 @@
-FROM alpine:3.20
-
-# Directory inside the assets image
-WORKDIR /assets
-
-# Copy assets
-COPY infrastructure/metabase /assets/
-
-RUN chmod +x /assets/*.sh

--- a/infrastructure/postgres/setup-analytics.sh
+++ b/infrastructure/postgres/setup-analytics.sh
@@ -14,7 +14,9 @@ set -euo pipefail
 : "${POSTGRES_PASSWORD:?Must set POSTGRES_PASSWORD}"
 : "${KEEP_ALIVE_SECONDS:=0}" # Prevent Swarm from marking this task as failed due to early exit
 
-TARGET_DB="events"
+TARGET_DB=${TARGET_DB-"events"}
+
+export TARGET_DB=${TARGET_DB//-/_}
 
 echo "Waiting for PostgreSQL to be ready at ${POSTGRES_HOST}:${POSTGRES_PORT}..."
 until PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

This PR aims to implement more common way to build assets image: https://github.com/opencrvs/opencrvs-core/issues/11192

See description at https://github.com/opencrvs/opencrvs-countryconfig/pull/1184

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
