### PR TITLE
fix: validate partial values in registrationDuration

### DIFF
--- a/src/form/tennis-club-membership.ts
+++ b/src/form/tennis-club-membership.ts
@@ -185,16 +185,26 @@ const TENNIS_CLUB_DECLARATION_FORM = defineDeclarationForm({
           validation: [
             {
               message: {
-                defaultMessage: 'Number and unit required for registration',
+                defaultMessage: 'Number and unit required',
                 description: 'This is the error message for invalid duration',
                 id: 'event.birth.action.declare.form.section.child.field.birthDuration.error'
               },
-              validator: and(
-                field('applicant.registrationDuration')
-                  .get('numericValue')
-                  .isGreaterThan(0),
-                not(
+              validator: or(
+                and(
+                  field('applicant.registrationDuration')
+                    .get('numericValue')
+                    .isFalsy(),
                   field('applicant.registrationDuration').get('unit').isFalsy()
+                ),
+                not(
+                  or(
+                    field('applicant.registrationDuration')
+                      .get('numericValue')
+                      .isFalsy(),
+                    field('applicant.registrationDuration')
+                      .get('unit')
+                      .isFalsy()
+                  )
                 )
               )
             }


### PR DESCRIPTION
The validation error would show up only if one of the unit and value are filled without the other.