### PR TITLE
Make reindex.sh fully posix compatible

### DIFF
--- a/infrastructure/deployment/reindex.sh
+++ b/infrastructure/deployment/reindex.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -38,12 +38,14 @@ fire_trigger() {
 # Both sides of the comparison are truncated to 19 chars (YYYY-MM-DDTHH:MM:SS)
 # to avoid the '.' < 'Z' string-sort trap with millisecond timestamps.
 fetch_latest_run_since() {
-  local token=$1 since=$2
+  local token=$1
+  local since
+  since=$(echo "$2" | cut -c1-19)
   curl -s \
     -H "Authorization: Bearer ${token}" \
     -H "Content-Type: application/json" \
     "${EVENTS_URL%/}/events/reindex" \
-  | jq -c --arg since "${since:0:19}" \
+  | jq -c --arg since "$since" \
     'map(select(.timestamp[0:19] >= $since)) | sort_by(.timestamp) | reverse | .[0] // empty'
 }
 
@@ -95,7 +97,8 @@ while true; do
     running)
       echo "  Running... ${PROCESSED} events processed so far"
       if [ "$polls" -gt "$MAX_POLLS" ]; then
-        echo "ERROR: reindex timed out after $(( polls * POLL_INTERVAL )) seconds."
+        timeout_secs=$(( polls * POLL_INTERVAL ))
+        echo "ERROR: reindex timed out after ${timeout_secs} seconds."
         exit 1
       fi
       ;;


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
