### PR TITLE
sort locations before syncing locations in analytics schema

### DIFF
--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -262,15 +262,46 @@ export async function importEvent(event: EventDocument, trx: Kysely<any>) {
   logger.info(`Event with id "${event.id}" logged into analytics`)
 }
 
+function sortLocationsByParentFirst(locations: Location[]): Location[] {
+  const locationMap = new Map(locations.map((loc) => [loc.id, loc]))
+  const result: Location[] = []
+  const visited = new Set<string>()
+
+  function addWithAncestors(loc: Location) {
+    if (visited.has(loc.id)) return
+
+    if (
+      loc.parentId &&
+      locationMap.has(loc.parentId) &&
+      !visited.has(loc.parentId)
+    ) {
+      addWithAncestors(locationMap.get(loc.parentId)!)
+    }
+
+    visited.add(loc.id)
+    result.push(loc)
+  }
+
+  for (const loc of locations) {
+    addWithAncestors(loc)
+  }
+
+  return result
+}
+
 export async function importLocations(locations: Location[]) {
   const client = getClient()
+
+  // Sort locations so that parent locations appear before their children
+  const sortedLocations = sortLocationsByParentFirst(locations)
+
   await client.transaction().execute(async (trx) => {
     for (const [index, batch] of chunk(
-      locations,
+      sortedLocations,
       INSERT_MAX_CHUNK_SIZE
     ).entries()) {
       logger.info(
-        `Importing ${Math.min((index + 1) * INSERT_MAX_CHUNK_SIZE, locations.length)}/${locations.length} locations`
+        `Importing ${Math.min((index + 1) * INSERT_MAX_CHUNK_SIZE, sortedLocations.length)}/${sortedLocations.length} locations`
       )
 
       await trx


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
