### PR TITLE
[OCRVS-11877] Explicitly tell reindex trigger endpoint not to wait for result

### DIFF
--- a/infrastructure/deployment/reindex.sh
+++ b/infrastructure/deployment/reindex.sh
@@ -30,7 +30,8 @@ fire_trigger() {
     -X POST \
     -H "Authorization: Bearer ${token}" \
     -H "Content-Type: application/json" \
-    "${EVENTS_URL%/}/events/reindex" &
+    -d '{"waitForCompletion": false}' \
+    "${EVENTS_URL%/}/events/reindex"
 }
 
 # Returns the most recent reindex status document whose timestamp >= $2,

--- a/infrastructure/deployment/reindex.sh
+++ b/infrastructure/deployment/reindex.sh
@@ -8,22 +8,17 @@
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
 
-set -euo pipefail
+set -eu
 
 EVENTS_URL="${EVENTS_URL:-http://localhost:5555/}"
 AUTH_URL="${AUTH_URL:-http://localhost:4040/}"
-# How often (seconds) to poll the status endpoint
 POLL_INTERVAL="${POLL_INTERVAL:-10}"
-# Maximum number of poll iterations (~3 hours at the default interval)
 MAX_POLLS="${MAX_POLLS:-1080}"
 
 get_reindexing_token() {
   curl -s "${AUTH_URL%/}/internal/reindexing-token" | jq -r '.token'
 }
 
-# Fires POST /events/reindex in a background subshell.
-# The response is intentionally discarded — reindexing can take a long time
-# and may even time out at the HTTP level. Progress is tracked via polling.
 fire_trigger() {
   local token=$1
   curl -s -o /dev/null \
@@ -34,10 +29,6 @@ fire_trigger() {
     "${EVENTS_URL%/}/events/reindex"
 }
 
-# Returns the most recent reindex status document whose timestamp >= $2,
-# as a compact JSON object, or empty string if none found yet.
-# Both sides of the comparison are truncated to 19 chars (YYYY-MM-DDTHH:MM:SS)
-# to avoid the '.' < 'Z' string-sort trap with millisecond timestamps.
 fetch_latest_run_since() {
   local token=$1
   local since
@@ -50,15 +41,6 @@ fetch_latest_run_since() {
     'map(select(.timestamp[0:19] >= $since)) | sort_by(.timestamp) | reverse | .[0] // empty'
 }
 
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
-# Capture wall-clock time BEFORE fetching the token so it is always
-# earlier than the status document the server writes. Stored timestamps
-# include milliseconds (e.g. 2026-03-06T09:53:08.123Z), so we keep only
-# the first 19 chars (YYYY-MM-DDTHH:MM:SS) for the comparison to avoid
-# the '.' < 'Z' string-sort trap.
 TRIGGER_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S")
 
 echo "Requesting reindex token..."
@@ -75,16 +57,15 @@ while true; do
     sleep 3
     first_poll=false
   else
-    sleep "$POLL_INTERVAL"
+    sleep "${POLL_INTERVAL}"
   fi
-  polls=$(( polls + 1 ))
+  polls=$(( ${polls:-0} + 1 ))
 
   RUN=$(fetch_latest_run_since "$TOKEN" "$TRIGGER_TIME")
 
   if [ -z "$RUN" ]; then
     echo "  Waiting for reindex to start... (${polls})"
-
-    if [ "$polls" -gt "$MAX_POLLS" ]; then
+    if [ "${polls}" -gt "${MAX_POLLS}" ]; then
       echo "ERROR: timed out waiting for reindex to start."
       exit 1
     fi
@@ -97,8 +78,8 @@ while true; do
   case "$STATUS" in
     running)
       echo "  Running... ${PROCESSED} events processed so far"
-      if [ "$polls" -gt "$MAX_POLLS" ]; then
-        timeout_secs=$(( polls * POLL_INTERVAL ))
+      if [ "${polls}" -gt "${MAX_POLLS}" ]; then
+        timeout_secs=$(( ${polls:-0} * ${POLL_INTERVAL:-10} ))
         echo "ERROR: reindex timed out after ${timeout_secs} seconds."
         exit 1
       fi
@@ -114,7 +95,7 @@ while true; do
       ;;
     *)
       echo "  Unknown status '${STATUS}' — continuing to poll..."
-      if [ "$polls" -gt "$MAX_POLLS" ]; then
+      if [ "${polls}" -gt "${MAX_POLLS}" ]; then
         exit 1
       fi
       ;;


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
