### PR TITLE
chore: add v2 scope for unassign

### DIFF
--- a/src/data-seeding/roles/roles.ts
+++ b/src/data-seeding/roles/roles.ts
@@ -65,7 +65,7 @@ export const roles: Role[] = [
       'type=record.register&event=birth,death,tennis-club-membership',
       'type=record.print-certified-copies&event=birth,death,tennis-club-membership',
       'type=record.correct&event=birth,death,tennis-club-membership',
-      'record.unassign-others[event=birth|death|tennis-club-membership]',
+      'type=record.unassign-others&event=birth,death,tennis-club-membership',
       'record.custom-action[event=birth,customActionType=ESCALATE|ISSUE_CERTIFIED_COPY]'
     ]
   },
@@ -145,7 +145,7 @@ export const roles: Role[] = [
       'type=record.correct&event=birth,death,tennis-club-membership',
       'record.custom-action[event=birth,customActionType=REGISTRAR_GENERAL_FEEDBACK|REVOKE_REGISTRATION|REINSTATE_REVOKE_REGISTRATION|APPROVE_DECLARATION]',
       'record.custom-action[event=death,customActionType=APPROVE_DECLARATION]',
-      'record.unassign-others[event=birth|death|tennis-club-membership]'
+      'type=record.unassign-others&event=birth,death,tennis-club-membership'
     ]
   },
   {


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
