### PR TITLE
rename custom events -> events

### DIFF
--- a/src/api/events/handler.ts
+++ b/src/api/events/handler.ts
@@ -15,30 +15,27 @@ import * as Hapi from '@hapi/hapi'
 import { sendInformantNotification } from '../notification/informantNotification'
 import { ActionConfirmationRequest } from '../registration'
 
-export function getCustomEventsHandler(
-  _: Hapi.Request,
-  h: Hapi.ResponseToolkit
-) {
+export function getEventsHandler(_: Hapi.Request, h: Hapi.ResponseToolkit) {
   return h
     .response([tennisClubMembershipEvent, birthEvent, deathEvent])
     .code(200)
 }
 
 export async function onCustomActionHandler(
-  request: ActionConfirmationRequest,
+  _: ActionConfirmationRequest,
   h: Hapi.ResponseToolkit
 ) {
   return h.response().code(200)
 }
 
+/**
+ * This catch-all action route will receive event actions with `Content-Type: application/json`
+ */
 export async function onAnyActionHandler(
   request: ActionConfirmationRequest,
   h: Hapi.ResponseToolkit
 ) {
-  // This catch-all event route will receive v2 events with `Content-Type: application/json`
-
   const token = request.auth.artifacts.token as string
-
   const event = request.payload
 
   await sendInformantNotification({ event, token })

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@
 require('app-module-path').addPath(require('path').join(__dirname))
 require('dotenv').config()
 
-import StreamArray from 'stream-json/streamers/StreamArray'
 import path from 'path'
 import * as Hapi from '@hapi/hapi'
 import * as Pino from 'hapi-pino'
@@ -49,10 +48,10 @@ import { applicationConfigHandler } from './api/application/handler'
 import { handlebarsHandler } from './form/common/certificate/handlebars/handler'
 import { fontsHandler } from './api/fonts/handler'
 import {
-  getCustomEventsHandler,
+  getEventsHandler,
   onAnyActionHandler,
   onCustomActionHandler
-} from '@countryconfig/api/custom-event/handler'
+} from '@countryconfig/api/events/handler'
 import {
   ActionDocument,
   ActionStatus,
@@ -494,7 +493,7 @@ export async function createServer() {
   server.route({
     method: 'GET',
     path: '/config/events',
-    handler: getCustomEventsHandler,
+    handler: getEventsHandler,
     options: {
       auth: false,
       tags: ['api', 'events'],
@@ -633,7 +632,8 @@ export async function createServer() {
       const url = new URL('events', GATEWAY_URL).toString()
       const apiClient = createClient(url, req.headers.authorization)
       const locations = await apiClient.locations.list.query()
-      const administrativeAreas = await apiClient.administrativeAreas.list.query()
+      const administrativeAreas =
+        await apiClient.administrativeAreas.list.query()
 
       await importAdministrativeAreas(administrativeAreas)
       await importLocations(locations)


### PR DESCRIPTION
## Description

* Rename directory `custom-event` -> `events`
* Rename fn `getCustomEventsHandler` -> `getEventsHandler`

Since events are custom by definition now

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
