### PR TITLE
fix: Create index for analytics.event_actions.event_id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.9.12
+
+### Improvements
+
+- Create index for analytics.event_actions.event_id field [#12182](https://github.com/opencrvs/opencrvs-core/issues/12182)
+
+
 ## 1.9.11
 
 ### Improvements

--- a/infrastructure/postgres/setup-analytics.sh
+++ b/infrastructure/postgres/setup-analytics.sh
@@ -87,6 +87,9 @@ CREATE TABLE IF NOT EXISTS analytics.event_actions (
   UNIQUE (id, event_id)
 );
 
+CREATE INDEX CONCURRENTLY IF NOT EXISTS analytics_idx_event_actions_event_id
+ON analytics.event_actions (event_id);
+
 CREATE TABLE IF NOT EXISTS analytics.location_levels (
   id text PRIMARY KEY,
   level int NOT NULL,


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Related issue: https://github.com/opencrvs/opencrvs-core/issues/12182

Added index for `analytics.event_actions.event_id` field.


## Testing

Following query was used to collect statistics:
```sql
SELECT calls,
       round(total_exec_time::numeric, 2) AS total_ms,
       round(mean_exec_time::numeric, 2) AS mean_ms,
       round(max_exec_time::numeric, 2) AS max_ms,
       rows,
       query
FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 20;
```

Results before index creation:
```
 calls  |  total_ms  | mean_ms | max_ms |  rows  |  queries
96796 | 1721298.43 |   17.78 |  50.79 | 291515 | delete from "analytics"."event_actions" where "event_id" = $1
```
Results after index creation:
```
 calls  | total_ms  | mean_ms | max_ms |  rows  |  query ...
    97132 |   1794.67 |    0.02 |   1.20 | 292739 | delete from "analytics"."event_actions" where "event_id" = $1
```

Results comparison:
- Query execution time lowered by 1000 from 1721298 (~25 minutes) to 1794 (~2 seconds)
- Reindex time reduces from 40 to 25 minutes. See screenshot:
   <img width="1075" height="472" alt="image" src="https://github.com/user-attachments/assets/2a7dcfcf-41d6-4448-86a6-96249cd28559" />

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
