### PR TITLE
Add allowedLocations config to place of death inputs

### DIFF
--- a/src/events/death/forms/pages/eventDetails.ts
+++ b/src/events/death/forms/pages/eventDetails.ts
@@ -328,7 +328,12 @@ export const eventDetails = defineFormPage({
           )
         }
       ],
-      configuration: { locationTypes: ['HEALTH_FACILITY'] }
+      configuration: {
+        locationTypes: ['HEALTH_FACILITY'],
+        allowedLocations: user.jurisdiction(
+          user.scope('record.create').attribute('placeOfEvent')
+        )
+      }
     },
     {
       id: 'eventDetails.deathLocationOther',
@@ -371,7 +376,10 @@ export const eventDetails = defineFormPage({
         administrativeArea: user('primaryOfficeId').locationLevel('district')
       },
       configuration: {
-        streetAddressForm: defaultStreetAddressConfiguration
+        streetAddressForm: defaultStreetAddressConfiguration,
+        allowedLocations: user.jurisdiction(
+          user.scope('record.create').attribute('placeOfEvent')
+        )
       }
     },
     {


### PR DESCRIPTION
## Description

Resolves comment: https://github.com/opencrvs/opencrvs-core/issues/11378#issuecomment-4162221116

Add `allowedLocations` config to place of death inputs to limit available options depending on user scope

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
