### PR TITLE
fix: use correct filepath in dockerfile

### DIFF
--- a/Dockerfile.assets
+++ b/Dockerfile.assets
@@ -9,7 +9,7 @@ COPY --chmod=755 infrastructure/metabase /assets/metabase
 # Postgres
 COPY --chmod=755 infrastructure/postgres /assets/postgres
 # Elasticsearch re-indexing
-COPY --chmod=755 infrastructure/deploy/reindex.sh /assets/elasticsearch/reindex.sh
+COPY --chmod=755 infrastructure/deployment/reindex.sh /assets/elasticsearch/reindex.sh
 
 # FIXME: This is a workaround to prevent the on-deploy.sh script from being executed in the assets image
 RUN rm -f /assets/postgres/on-deploy.sh


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Issue: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/23938473463/job/69848177587
`"/infrastructure/deploy/reindex.sh": not found`


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
