### PR TITLE
fix(roles): remove edit scope from provincial registrar

### DIFF
--- a/src/data-seeding/roles/roles.ts
+++ b/src/data-seeding/roles/roles.ts
@@ -165,7 +165,6 @@ export const roles: Role[] = [
       'workqueue[id=recent|pending-feedback-provincinal-registrar|pending-approval|correction-requested]',
       'type=record.read&placeOfEvent=administrativeArea',
       'type=record.reject&placeOfEvent=administrativeArea',
-      'type=record.edit&placeOfEvent=administrativeArea',
       'type=record.register&declaredIn=administrativeArea',
       'type=record.archive&placeOfEvent=administrativeArea',
       'type=record.custom-action&event=birth&customActionTypes=PROVINCIAL_REGISTER_FEEDBACK,REINSTATE_REVOKE_REGISTRATION,ESCALATE&placeOfEvent=administrativeArea',


### PR DESCRIPTION
Addresses https://github.com/opencrvs/opencrvs-core/issues/11451

Farajaland PR: https://github.com/opencrvs/opencrvs-farajaland/pull/2072

> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Removes the `record.edit` scope from the Provincial Registrar role.

**Root cause:** The Provincial Registrar had edit scope, which allowed them to edit a declaration before approving it. The EDIT action unconditionally removes the `approval-required-for-late-registration` flag. When the Provincial Registrar then declared with edits, the DECLARE action re-evaluated the late DOB condition and re-added the flag — sending the record back into the approval queue and creating a stuck loop.

**Fix:** Provincial Registrar should only approve or reject declarations. Removing edit scope from their role prevents this loop. If changes are needed, the record should be rejected so the original declarant can make corrections.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly