### PR TITLE
Add index for event_actions to make db operations faster

### DIFF
--- a/infrastructure/postgres/setup-analytics.sh
+++ b/infrastructure/postgres/setup-analytics.sh
@@ -95,6 +95,7 @@ CREATE TABLE IF NOT EXISTS analytics.event_actions (
 
 ALTER TABLE analytics.event_actions ADD COLUMN IF NOT EXISTS custom_action_type TEXT;
 ALTER TABLE analytics.event_actions ALTER COLUMN created_by_role DROP NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_event_actions_event_id ON analytics.event_actions (event_id);
 
 CREATE TABLE IF NOT EXISTS analytics.location_levels (
   id text PRIMARY KEY,

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -265,19 +265,28 @@ async function upsertAnalyticsEventActions(
     return []
   }
 
-  return trx
-    .insertInto('analytics.event_actions')
-    .values(allEventActions)
-    .onConflict((oc) =>
-      oc.column('id').doUpdateSet((eb) =>
-        Object.fromEntries(
-          Object.keys(allEventActions[0])
-            .filter((key) => key !== 'id')
-            .map((key) => [key, eb.ref(`excluded.${key}`)])
+  /*
+   * This must be chunked not to cause an error if one event happens to have
+   * 10k actions
+   */
+  const chunks = chunk(allEventActions, 3000)
+
+  for (const batch of chunks) {
+    await trx
+      .insertInto('analytics.event_actions')
+      .values(batch)
+      .onConflict((oc) =>
+        oc.column('id').doUpdateSet((eb) =>
+          Object.fromEntries(
+            Object.keys(allEventActions[0])
+              .filter((key) => key !== 'id')
+              .map((key) => [key, eb.ref(`excluded.${key}`)])
+          )
         )
       )
-    )
-    .execute()
+      .execute()
+  }
+  return
 }
 
 export async function importEvents(events: EventDocument[], trx: Kysely<any>) {

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -204,6 +204,13 @@ async function upsertAnalyticsEventActions(
 
       const action = event.actions[i]
 
+      if (
+        action.status === ActionStatus.Requested ||
+        action.status === ActionStatus.Rejected
+      ) {
+        continue
+      }
+
       const actionAtCurrentPoint = getCurrentEventState(
         {
           ...event,
@@ -213,13 +220,6 @@ async function upsertAnalyticsEventActions(
       )
 
       const { type, ...act } = action
-
-      if (
-        action.status === ActionStatus.Requested ||
-        action.status === ActionStatus.Rejected
-      ) {
-        continue
-      }
 
       const actionConfig = eventConfig.actions.find((a) => a.type === type)
 


### PR DESCRIPTION
Makes suree the batches we write to analytics table are not too large even in the case of event with 10k actions

> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
