### PR TITLE
Conditionally hide 'Place of delivery' options based on user role

### DIFF
--- a/src/events/birth/advancedSearch.ts
+++ b/src/events/birth/advancedSearch.ts
@@ -10,7 +10,26 @@
  */
 
 import { AdvancedSearchConfig, event, field } from '@opencrvs/toolkit/events'
-import { placeOfBirthOptions } from './forms/pages/child'
+import { SelectOption } from '@opencrvs/toolkit/events'
+import {
+  PlaceOfBirth,
+  placeOfBirthMessageDescriptors
+} from './forms/pages/child'
+
+const placeOfBirthOptions = [
+  {
+    value: PlaceOfBirth.HEALTH_FACILITY,
+    label: placeOfBirthMessageDescriptors.HEALTH_FACILITY
+  },
+  {
+    value: PlaceOfBirth.PRIVATE_HOME,
+    label: placeOfBirthMessageDescriptors.PRIVATE_HOME
+  },
+  {
+    value: PlaceOfBirth.OTHER,
+    label: placeOfBirthMessageDescriptors.OTHER
+  }
+] satisfies SelectOption[]
 
 const childPrefix = {
   id: 'birth.search.criteria.label.prefix.child',

--- a/src/events/birth/forms/pages/child.ts
+++ b/src/events/birth/forms/pages/child.ts
@@ -19,7 +19,8 @@ import {
   or,
   PageTypes,
   field,
-  user
+  user,
+  SelectOption
 } from '@opencrvs/toolkit/events'
 import { not } from '@opencrvs/toolkit/conditionals'
 
@@ -149,7 +150,7 @@ const attendantAtBirthMessageDescriptors = {
   }
 } satisfies Record<keyof typeof AttendantAtBirth, TranslationConfig>
 
-const placeOfBirthMessageDescriptors = {
+export const placeOfBirthMessageDescriptors = {
   HEALTH_FACILITY: {
     defaultMessage: 'Health Institution',
     description: 'Select item for Health Institution',
@@ -169,10 +170,38 @@ const placeOfBirthMessageDescriptors = {
 
 const genderOptions = createSelectOptions(GenderTypes, genderMessageDescriptors)
 
-export const placeOfBirthOptions = createSelectOptions(
-  PlaceOfBirth,
-  placeOfBirthMessageDescriptors
-)
+const placeOfBirthOptions = [
+  {
+    value: PlaceOfBirth.HEALTH_FACILITY,
+    label: placeOfBirthMessageDescriptors.HEALTH_FACILITY,
+    conditionals: [
+      {
+        type: ConditionalType.SHOW,
+        conditional: not(user.hasRole('EMBASSY_OFFICIAL'))
+      }
+    ]
+  },
+  {
+    value: PlaceOfBirth.PRIVATE_HOME,
+    label: placeOfBirthMessageDescriptors.PRIVATE_HOME,
+    conditionals: [
+      {
+        type: ConditionalType.SHOW,
+        conditional: not(user.hasRole('HOSPITAL_CLERK'))
+      }
+    ]
+  },
+  {
+    value: PlaceOfBirth.OTHER,
+    label: placeOfBirthMessageDescriptors.OTHER.defaultMessage,
+    conditionals: [
+      {
+        type: ConditionalType.SHOW,
+        conditional: not(user.hasRole('HOSPITAL_CLERK'))
+      }
+    ]
+  }
+] satisfies SelectOption[]
 
 const typeOfBirthOptions = createSelectOptions(
   TypeOfBirth,


### PR DESCRIPTION
## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/12259
e2e pass: https://github.com/opencrvs/e2e/actions/runs/24891016273

Let's do this only for birth events now, and implement for death after birth changes have gone through QA.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
