### PR TITLE
fix: Reindex token refresh for get status

### DIFF
--- a/infrastructure/deployment/reindex.sh
+++ b/infrastructure/deployment/reindex.sh
@@ -32,13 +32,53 @@ fire_trigger() {
 fetch_latest_run_since() {
   local token=$1
   local since
+  local response
+  local tmp
+  local json_type
+  local code
+
   since=$(echo "$2" | cut -c1-19)
-  curl -s \
+  tmp=$(mktemp)
+
+  response=$(curl -sS \
     -H "Authorization: Bearer ${token}" \
     -H "Content-Type: application/json" \
-    "${EVENTS_URL%/}/events/reindex" \
-  | jq -c --arg since "$since" \
-    'map(select(.timestamp[0:19] >= $since)) | sort_by(.timestamp) | reverse | .[0] // empty'
+    "${EVENTS_URL%/}/events/reindex" 2>&1) || {
+      echo "ERROR: failed to fetch reindex status:" >&2
+      echo "$response" >&2
+      rm -f "$tmp"
+      return 1
+    }
+
+  printf '%s' "$response" > "$tmp"
+
+  json_type=$(jq -r 'type' "$tmp" 2>/dev/null) || {
+    echo "ERROR: reindex status response is not valid JSON:" >&2
+    cat "$tmp" >&2
+    rm -f "$tmp"
+    return 1
+  }
+
+  if [ "$json_type" != "array" ]; then
+    code=$(jq -r '.code // .data.code // empty' "$tmp")
+
+    if [ "$code" = "UNAUTHORIZED" ]; then
+      echo "WARN: reindex status token expired; refreshing token..." >&2
+      rm -f "$tmp"
+      return 2
+    fi
+
+    echo "ERROR: unexpected reindex status response:" >&2
+    jq -c '.' "$tmp" >&2
+    rm -f "$tmp"
+    return 1
+  fi
+
+  jq -c --arg since "$since" \
+    'map(select(.timestamp[0:19] >= $since)) | sort_by(.timestamp) | reverse | .[0] // empty' \
+    "$tmp"
+
+  rm -f "$tmp"
 }
 
 TRIGGER_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S")
@@ -61,7 +101,26 @@ while true; do
   fi
   polls=$(( ${polls:-0} + 1 ))
 
-  RUN=$(fetch_latest_run_since "$TOKEN" "$TRIGGER_TIME")
+  if RUN=$(fetch_latest_run_since "$TOKEN" "$TRIGGER_TIME"); then
+    :
+  else
+    rc=$?
+
+    if [ "$rc" -eq 2 ]; then
+        echo "  Token expired, refreshing token..."
+        TOKEN=$(get_reindexing_token)
+
+        if RUN=$(fetch_latest_run_since "$TOKEN" "$TRIGGER_TIME"); then
+          :
+        else
+          echo "ERROR: failed to fetch reindex status after refreshing token."
+          exit 1
+        fi
+      else
+        echo "ERROR: failed to fetch reindex status."
+        exit 1
+      fi
+  fi
 
   if [ -z "$RUN" ]; then
     echo "  Waiting for reindex to start... (${polls})"


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Handle expired reindex token during polling and avoid duplicate triggers.
Adds retry with token refresh when /events/reindex returns UNAUTHORIZED, plus pre-check to skip triggering if a reindex is already running.

# Testing

Reindex run: https://github.com/opencrvs/opencrvs-farajaland-infrastructure/actions/runs/25335102902/job/74278227648

<img width="709" height="194" alt="image" src="https://github.com/user-attachments/assets/e4ae8053-32c2-4f0a-ac1d-f1dfeb629e4d" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
