### PR TITLE
chore: give user.search scope to relevant users

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/toolkit": "2.0.0-rc.4ac5bfa",
+    "@opencrvs/toolkit": "2.0.0-rc.61bee9f",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",
     "@types/fhir": "^0.0.30",

--- a/src/data-seeding/roles/roles.ts
+++ b/src/data-seeding/roles/roles.ts
@@ -19,6 +19,7 @@ export const roles: Role[] = [
       { type: 'performance.read' },
       { type: 'organisation.read-locations', options: { accessLevel: 'administrativeArea' } },
       { type: 'user.read', options: { accessLevel: 'administrativeArea' } },
+      { type: 'user.search' },
       { type: 'performance.read-dashboards' },
       { type: 'workqueue', options: { ids: ['assigned-to-you', 'recent', 'requires-completion', 'in-external-validation', 'escalated', 'pending-validation', 'pending-updates', 'pending-approval', 'pending-certification', 'pending-issuance', 'correction-requested'] } },
       { type: 'record.search', options: { placeOfEvent: 'administrativeArea' } },
@@ -51,6 +52,7 @@ export const roles: Role[] = [
       { type: 'performance.read' },
       { type: 'organisation.read-locations', options: { accessLevel: 'administrativeArea' } },
       { type: 'user.read', options: { accessLevel: 'administrativeArea' } },
+      { type: 'user.search' },
       { type: 'performance.read-dashboards' },
       {
         type: 'workqueue',
@@ -88,7 +90,8 @@ export const roles: Role[] = [
         { type: 'organisation.read-locations', options: { accessLevel: 'administrativeArea' } },
         { type: 'user.create', options: { accessLevel: 'administrativeArea', role: ['HOSPITAL_CLERK', 'COMMUNITY_LEADER', 'REGISTRATION_AGENT', 'LOCAL_REGISTRAR', 'PROVINCIAL_REGISTRAR'] } },
         { type: 'user.edit', options: { accessLevel: 'administrativeArea', role: ['HOSPITAL_CLERK', 'COMMUNITY_LEADER', 'REGISTRATION_AGENT', 'LOCAL_REGISTRAR', 'PROVINCIAL_REGISTRAR'] } },
-        { type: 'user.read', options: { accessLevel: 'administrativeArea' } }
+        { type: 'user.read', options: { accessLevel: 'administrativeArea' } },
+        { type: 'user.search' }
       ])
     ]
   },
@@ -106,6 +109,7 @@ export const roles: Role[] = [
         { type: 'user.create', options: { role: ['HOSPITAL_CLERK', 'COMMUNITY_LEADER', 'REGISTRATION_AGENT', 'LOCAL_REGISTRAR', 'NATIONAL_REGISTRAR', 'LOCAL_SYSTEM_ADMIN', 'NATIONAL_SYSTEM_ADMIN', 'PERFORMANCE_MANAGER', 'PROVINCIAL_REGISTRAR', 'EMBASSY_OFFICIAL'] } },
         { type: 'user.edit', options: { role: ['HOSPITAL_CLERK', 'COMMUNITY_LEADER', 'REGISTRATION_AGENT', 'LOCAL_REGISTRAR', 'NATIONAL_REGISTRAR', 'LOCAL_SYSTEM_ADMIN', 'NATIONAL_SYSTEM_ADMIN', 'PERFORMANCE_MANAGER', 'PROVINCIAL_REGISTRAR', 'EMBASSY_OFFICIAL'] } },
         { type: 'user.read' },
+        { type: 'user.search' },
         { type: 'performance.read' },
         { type: 'record.reindex' },
         { type: 'integration.create' },
@@ -127,6 +131,7 @@ export const roles: Role[] = [
     scopes: defineScopes([
       { type: 'performance.read' },
       { type: 'organisation.read-locations' },
+      { type: 'user.search' },
       { type: 'performance.read-dashboards' },
       {
         type: 'dashboard.view',
@@ -142,6 +147,7 @@ export const roles: Role[] = [
       { type: 'performance.read' },
       { type: 'organisation.read-locations' },
       { type: 'user.read' },
+      { type: 'user.search' },
       { type: 'record.search' },
       { type: 'workqueue', options: { ids: ['assigned-to-you', 'recent', 'pending-feedback-registrar-general', 'potential-duplicate', 'registration-registrar-general'] } },
       { type: 'record.read' },
@@ -167,6 +173,7 @@ export const roles: Role[] = [
     scopes: defineScopes([
       { type: 'organisation.read-locations', options: { accessLevel: 'administrativeArea' } },
       { type: 'user.read', options: { accessLevel: 'administrativeArea' } },
+      { type: 'user.search' },
       { type: 'performance.read' },
       { type: 'performance.read-dashboards' },
       { type: 'profile.electronic-signature' },

--- a/src/data-seeding/roles/roles.ts
+++ b/src/data-seeding/roles/roles.ts
@@ -19,7 +19,7 @@ export const roles: Role[] = [
       { type: 'performance.read' },
       { type: 'organisation.read-locations', options: { accessLevel: 'administrativeArea' } },
       { type: 'user.read', options: { accessLevel: 'administrativeArea' } },
-      { type: 'user.search' },
+      { type: 'user.search', options: { accessLevel: 'administrativeArea' } },
       { type: 'performance.read-dashboards' },
       { type: 'workqueue', options: { ids: ['assigned-to-you', 'recent', 'requires-completion', 'in-external-validation', 'escalated', 'pending-validation', 'pending-updates', 'pending-approval', 'pending-certification', 'pending-issuance', 'correction-requested'] } },
       { type: 'record.search', options: { placeOfEvent: 'administrativeArea' } },
@@ -52,7 +52,7 @@ export const roles: Role[] = [
       { type: 'performance.read' },
       { type: 'organisation.read-locations', options: { accessLevel: 'administrativeArea' } },
       { type: 'user.read', options: { accessLevel: 'administrativeArea' } },
-      { type: 'user.search' },
+      { type: 'user.search', options: { accessLevel: 'administrativeArea' } },
       { type: 'performance.read-dashboards' },
       {
         type: 'workqueue',
@@ -91,7 +91,7 @@ export const roles: Role[] = [
         { type: 'user.create', options: { accessLevel: 'administrativeArea', role: ['HOSPITAL_CLERK', 'COMMUNITY_LEADER', 'REGISTRATION_AGENT', 'LOCAL_REGISTRAR', 'PROVINCIAL_REGISTRAR'] } },
         { type: 'user.edit', options: { accessLevel: 'administrativeArea', role: ['HOSPITAL_CLERK', 'COMMUNITY_LEADER', 'REGISTRATION_AGENT', 'LOCAL_REGISTRAR', 'PROVINCIAL_REGISTRAR'] } },
         { type: 'user.read', options: { accessLevel: 'administrativeArea' } },
-        { type: 'user.search' }
+        { type: 'user.search', options: { accessLevel: 'administrativeArea' } }
       ])
     ]
   },
@@ -173,7 +173,7 @@ export const roles: Role[] = [
     scopes: defineScopes([
       { type: 'organisation.read-locations', options: { accessLevel: 'administrativeArea' } },
       { type: 'user.read', options: { accessLevel: 'administrativeArea' } },
-      { type: 'user.search' },
+      { type: 'user.search', options: { accessLevel: 'administrativeArea' } },
       { type: 'performance.read' },
       { type: 'performance.read-dashboards' },
       { type: 'profile.electronic-signature' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -802,10 +802,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opencrvs/toolkit@2.0.0-rc.4ac5bfa":
-  version "2.0.0-rc.4ac5bfa"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-2.0.0-rc.4ac5bfa.tgz#1667e21004c7d79ee15132c81fa541d4fda44472"
-  integrity sha512-NWJvz52u8rqD3BBvD4xETjWY+Hjkv81lICs3QsnqCEvQvgiYOAi8ZQfyiRd6nNjrv0bcXSCp5oNbykfOZE63QA==
+"@opencrvs/toolkit@2.0.0-rc.61bee9f":
+  version "2.0.0-rc.61bee9f"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-2.0.0-rc.61bee9f.tgz#3614c1ebd1549c54cbd5704e84057ce244a4d316"
+  integrity sha512-xHFeWRX/R78LnTjGI3knj1Y8KrjDHW+8c4cXlH16DEOvAAwGnWHn5RcSTjSdjH5myoAsGjjHYbO7EDAtdLww4A==
   dependencies:
     "@trpc/client" "11.4.3"
     "@trpc/server" "^11.8.0"


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
