### PR TITLE
fix (release-automation): re-organize `init-release` workflow steps 

### DIFF
--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -6,19 +6,40 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-name: Release - Start a new release 
+
+# Gitflow release initialisation workflow.
+#
+# Triggered by opencrvs-core's init-release workflow (or manually) with a
+# semver version string (e.g. 1.7.2).
+#
+# What this workflow does, in order:
+#   1. Derives the base branch:
+#        - patch release (z > 0)  → release/<x>.<y>.<z-1>
+#        - minor/major (z = 0)    → develop
+#   2. Creates a release branch (release/<version>) from the base branch.
+#   3. Bumps package.json and prepends a CHANGELOG section, then pushes
+#      both commits to the release branch.
+#   4. Opens two PRs — both PRs already contain the version-bump commits:
+#        a. release/<version> → master   (the release PR)
+#        b. release/<version> → develop  (merge-back PR, keeps develop in sync)
+#   5. Creates a draft GitHub release and immediately deletes the backing tag
+#      (the tag will be re-created by the publish workflow after the PR merges).
+name: Release - Start a new release
 on:
   workflow_dispatch:
     inputs:
       version:
         type: string
         required: true
-        description: "Version to release"
-  
+        description: 'Version to release'
+
 jobs:
   release_workflow:
     runs-on: ubuntu-latest
     steps:
+      # Derive base_branch and target_branch from the version number.
+      #   - patch (z > 0): base = release/<x>.<y>.<z-1>, target = master
+      #   - minor/major (z = 0): base = develop, target = master
       - name: Determine the Base Branch
         id: get_base_branch
         run: |
@@ -39,53 +60,34 @@ jobs:
           fi
           echo "target_branch=master" >> $GITHUB_OUTPUT
           echo "base_branch=$base_branch" >> $GITHUB_OUTPUT
-                 
-      - name: Start a new release ${{ inputs.version }} from ${{ steps.get_base_branch.outputs.base_branch }}
-        uses: hoangvvo/gitflow-workflow-action@0.3.8
-        with:
-          develop_branch: ${{ steps.get_base_branch.outputs.base_branch }}
-          main_branch: ${{ steps.get_base_branch.outputs.target_branch }}
-          merge_back_from_main: false
-          version: ${{ inputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout the release branch
+      # Full history is required so yarn can traverse the commit graph.
+      - name: Checkout ${{ steps.get_base_branch.outputs.base_branch }}
         uses: actions/checkout@v4
         with:
-          ref: "release/${{ inputs.version }}"
+          ref: ${{ steps.get_base_branch.outputs.base_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Clear auto-generated PR comment
+      # Create the release branch, bump package.json, and update the
+      # CHANGELOG — then push. The PRs are opened only after these commits
+      # exist on the remote, so both PRs immediately include the version-bump
+      # commits.
+      - name: Create release branch and update version numbers and CHANGELOG
         run: |
-          REPO="${{ github.repository }}"
-          PR_BRANCH="release/${{ inputs.version }}"
-          PR_NUMBER=$(gh pr list --head "$PR_BRANCH" --repo "$REPO" --json number -q '.[0].number')
-          cd "$GITHUB_WORKSPACE"
-          if [ -f .github/TEMPLATES/RELEASE_PR_TEMPLATE.md ]; then
-            BODY=$(jq -Rs . < .github/TEMPLATES/RELEASE_PR_TEMPLATE.md)
-          else
-            BODY=$(jq -n --arg body "" '$body')
-          fi
-          echo "{\"body\": $BODY}" > body.json
-          gh api \
-            --method PATCH \
-            -H "Accept: application/vnd.github.v3+json" \
-            /repos/"$REPO"/issues/"$PR_NUMBER" \
-            --input body.json 
-          rm body.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
-      - name: Update version numbers and CHANGELOG
-        run: |
-          cd "$GITHUB_WORKSPACE"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          git checkout -b "release/${{ inputs.version }}"
+
+          # Bump package.json without creating a git tag.
           yarn version --new-version ${{ inputs.version }} --no-git-tag-version
           git add .
           git commit -m "chore: update version to ${{ inputs.version }}"
 
+          # Prepend a new "Release Candidate" section to the top of CHANGELOG.md.
+          # sed removes the existing "# Changelog" header (lines 1-2) so we can
+          # rewrite it with the new section underneath.
           sed -i '1,2d' CHANGELOG.md
           cp CHANGELOG.md COPY_CHANGELOG.md
           {
@@ -93,8 +95,70 @@ jobs:
             echo ""
             echo "## ${{ inputs.version }} Release Candidate"
             echo ""
-            cat COPY_CHANGELOG.md 
+            cat COPY_CHANGELOG.md
           } > CHANGELOG.md
+          rm COPY_CHANGELOG.md
           git add CHANGELOG.md
           git commit -m "docs: update changelog for ${{ inputs.version }} release candidate"
+
           git push origin "release/${{ inputs.version }}"
+
+      # Two PRs are always created:
+      #
+      #   PR 1 — release/<version> → master
+      #     The release PR. Merging this ships the version to production.
+      #
+      #   PR 2 — release/<version> → develop
+      #     The merge-back PR. Ensures the version-bump commits (and any fixes
+      #     cherry-picked onto the release branch) flow back into develop so the
+      #     next development cycle starts from the correct version.
+      #     This PR is always created regardless of what the base branch was:
+      #       - z=0 (base is develop): carries only the two bump commits, clean diff.
+      #       - z>0 (base is a prior release branch): also backports any patch fixes.
+      - name: Create Pull Requests
+        run: |
+          PR_BRANCH="release/${{ inputs.version }}"
+          TARGET_BRANCH="${{ steps.get_base_branch.outputs.target_branch }}"
+
+          if [ -f .github/TEMPLATES/RELEASE_PR_TEMPLATE.md ]; then
+            BODY=$(cat .github/TEMPLATES/RELEASE_PR_TEMPLATE.md)
+          else
+            BODY=""
+          fi
+
+          gh pr create \
+            --base "$TARGET_BRANCH" \
+            --head "$PR_BRANCH" \
+            --title "Release v${{ inputs.version }}" \
+            --body "$BODY"
+
+          gh pr create \
+            --base "develop" \
+            --head "$PR_BRANCH" \
+            --title "chore: merge release v${{ inputs.version }} back to develop" \
+            --body "Merge release branch back to develop to include version bump and changelog updates."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Create a draft release so the release notes page exists immediately.
+      # The tag is deleted right after: the publish workflow re-creates it when
+      # the release PR is merged into master, which is the canonical tag point.
+      - name: Create a draft release
+        run: |
+          TAG_NAME="v${{ inputs.version }}"
+          TITLE="OpenCRVS - $TAG_NAME"
+          NOTES="Release notes for version ${{ inputs.version }}"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+          gh release create "$TAG_NAME" \
+            --title "$TITLE" \
+            --notes "$NOTES" \
+            --draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete the tag
+        run: |
+          TAG_NAME="v${{ inputs.version }}"
+          git tag -d "$TAG_NAME"
+          git push origin ":refs/tags/$TAG_NAME"

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           ref: ${{ steps.get_base_branch.outputs.base_branch }}
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if release branch already exists
         id: check_branch
@@ -85,8 +86,6 @@ jobs:
       # Skipped if the release branch was already created by a previous run.
       - name: Create release branch and update version numbers and CHANGELOG
         if: steps.check_branch.outputs.exists == 'false'
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -163,7 +162,7 @@ jobs:
             echo "PR release/${{ inputs.version }} → develop already exists (#$EXISTING_DEVELOP_PR), skipping."
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Create a draft release so the release notes page exists immediately.
       # The tag is deleted right after: the publish workflow re-creates it when

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -74,11 +74,23 @@ jobs:
           ref: ${{ steps.get_base_branch.outputs.base_branch }}
           fetch-depth: 0
 
+      - name: Check if release branch already exists
+        id: check_branch
+        run: |
+          if git ls-remote --exit-code --heads origin "release/${{ inputs.version }}" > /dev/null 2>&1; then
+            echo "Branch release/${{ inputs.version }} already exists, skipping creation."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       # Create the release branch, bump package.json, and update the
       # CHANGELOG — then push. The PRs are opened only after these commits
       # exist on the remote, so both PRs immediately include the version-bump
       # commits.
+      # Skipped if the release branch was already created by a previous run.
       - name: Create release branch and update version numbers and CHANGELOG
+        if: steps.check_branch.outputs.exists == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -120,6 +132,8 @@ jobs:
       #     This PR is always created regardless of what the base branch was:
       #       - z=0 (base is develop): carries only the two bump commits, clean diff.
       #       - z>0 (base is a prior release branch): also backports any patch fixes.
+      # Each PR is checked individually — one may already exist while the other
+      # does not, so both are always evaluated.
       - name: Create Pull Requests
         run: |
           PR_BRANCH="release/${{ inputs.version }}"
@@ -131,17 +145,27 @@ jobs:
             BODY=""
           fi
 
-          gh pr create \
-            --base "$TARGET_BRANCH" \
-            --head "$PR_BRANCH" \
-            --title "Release v${{ inputs.version }}" \
-            --body "$BODY"
+          EXISTING_MASTER_PR=$(gh pr list --head "$PR_BRANCH" --base "$TARGET_BRANCH" --state open --json number --jq '.[0].number // ""')
+          if [ -z "$EXISTING_MASTER_PR" ]; then
+            gh pr create \
+              --base "$TARGET_BRANCH" \
+              --head "$PR_BRANCH" \
+              --title "Release v${{ inputs.version }}" \
+              --body "$BODY"
+          else
+            echo "PR release/${{ inputs.version }} → $TARGET_BRANCH already exists (#$EXISTING_MASTER_PR), skipping."
+          fi
 
-          gh pr create \
-            --base "develop" \
-            --head "$PR_BRANCH" \
-            --title "chore: merge release v${{ inputs.version }} back to develop" \
-            --body "Merge release branch back to develop to include version bump and changelog updates."
+          EXISTING_DEVELOP_PR=$(gh pr list --head "$PR_BRANCH" --base "develop" --state open --json number --jq '.[0].number // ""')
+          if [ -z "$EXISTING_DEVELOP_PR" ]; then
+            gh pr create \
+              --base "develop" \
+              --head "$PR_BRANCH" \
+              --title "chore: merge release v${{ inputs.version }} back to develop" \
+              --body "Merge release branch back to develop to include version bump and changelog updates."
+          else
+            echo "PR release/${{ inputs.version }} → develop already exists (#$EXISTING_DEVELOP_PR), skipping."
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -36,6 +36,12 @@ on:
 jobs:
   release_workflow:
     runs-on: ubuntu-latest
+    # Explicitly declare required permissions as a safety net — org-level
+    # defaults may vary. contents: write for git push; pull-requests: write
+    # for gh pr create.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # Derive base_branch and target_branch from the version number.
       #   - patch (z > 0): base = release/<x>.<y>.<z-1>, target = master
@@ -62,14 +68,11 @@ jobs:
           echo "base_branch=$base_branch" >> $GITHUB_OUTPUT
 
       # Full history is required so yarn can traverse the commit graph.
-      # GH_TOKEN (PAT) is used instead of GITHUB_TOKEN so that git push has
-      # write access — GITHUB_TOKEN may be read-only depending on repo settings.
       - name: Checkout ${{ steps.get_base_branch.outputs.base_branch }}
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.get_base_branch.outputs.base_branch }}
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
 
       # Create the release branch, bump package.json, and update the
       # CHANGELOG — then push. The PRs are opened only after these commits
@@ -140,7 +143,7 @@ jobs:
             --title "chore: merge release v${{ inputs.version }} back to develop" \
             --body "Merge release branch back to develop to include version bump and changelog updates."
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Create a draft release so the release notes page exists immediately.
       # The tag is deleted right after: the publish workflow re-creates it when
@@ -157,7 +160,7 @@ jobs:
             --notes "$NOTES" \
             --draft
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Delete the tag
         run: |

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -115,16 +115,27 @@ jobs:
 
           git push origin "release/${{ inputs.version }}"
 
+      # A dedicated merge-back branch is used for the develop PR so that any
+      # conflict-resolution commits do not land on the release branch itself.
+      - name: Create merge-back branch for develop PR
+        run: |
+          MERGEBACK_BRANCH="merge-back/release-${{ inputs.version }}-to-develop"
+          if git ls-remote --exit-code --heads origin "$MERGEBACK_BRANCH" > /dev/null 2>&1; then
+            echo "Branch $MERGEBACK_BRANCH already exists, skipping."
+          else
+            git fetch origin "release/${{ inputs.version }}"
+            git checkout -b "$MERGEBACK_BRANCH" "origin/release/${{ inputs.version }}"
+            git push origin "$MERGEBACK_BRANCH"
+          fi
+
       # Two PRs are always created:
       #
       #   PR 1 — release/<version> → master
       #     The release PR. Merging this ships the version to production.
       #
-      #   PR 2 — release/<version> → develop
-      #     The merge-back PR. Ensures the version-bump commits (and any fixes
-      #     cherry-picked onto the release branch) flow back into develop so the
-      #     next development cycle starts from the correct version.
-      #     This PR is always created regardless of what the base branch was:
+      #   PR 2 — merge-back/release-<version>-to-develop → develop
+      #     Uses a dedicated branch so conflict-resolution commits stay off
+      #     the release branch.
       #       - z=0 (base is develop): carries only the two bump commits, clean diff.
       #       - z>0 (base is a prior release branch): also backports any patch fixes.
       # Each PR is checked individually — one may already exist while the other
@@ -132,6 +143,7 @@ jobs:
       - name: Create Pull Requests
         run: |
           PR_BRANCH="release/${{ inputs.version }}"
+          MERGEBACK_BRANCH="merge-back/release-${{ inputs.version }}-to-develop"
           TARGET_BRANCH="${{ steps.get_base_branch.outputs.target_branch }}"
 
           if [ -f .github/TEMPLATES/RELEASE_PR_TEMPLATE.md ]; then
@@ -148,18 +160,18 @@ jobs:
               --title "Release v${{ inputs.version }}" \
               --body "$BODY"
           else
-            echo "PR release/${{ inputs.version }} → $TARGET_BRANCH already exists (#$EXISTING_MASTER_PR), skipping."
+            echo "PR $PR_BRANCH → $TARGET_BRANCH already exists (#$EXISTING_MASTER_PR), skipping."
           fi
 
-          EXISTING_DEVELOP_PR=$(gh pr list --head "$PR_BRANCH" --base "develop" --state open --json number --jq '.[0].number // ""')
+          EXISTING_DEVELOP_PR=$(gh pr list --head "$MERGEBACK_BRANCH" --base "develop" --state open --json number --jq '.[0].number // ""')
           if [ -z "$EXISTING_DEVELOP_PR" ]; then
             gh pr create \
               --base "develop" \
-              --head "$PR_BRANCH" \
+              --head "$MERGEBACK_BRANCH" \
               --title "chore: merge release v${{ inputs.version }} back to develop" \
               --body "Merge release branch back to develop to include version bump and changelog updates."
           else
-            echo "PR release/${{ inputs.version }} → develop already exists (#$EXISTING_DEVELOP_PR), skipping."
+            echo "PR $MERGEBACK_BRANCH → develop already exists (#$EXISTING_DEVELOP_PR), skipping."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -167,22 +179,31 @@ jobs:
       # Create a draft release so the release notes page exists immediately.
       # The tag is deleted right after: the publish workflow re-creates it when
       # the release PR is merged into master, which is the canonical tag point.
+      # Skipped if a release for this version already exists from a previous run.
       - name: Create a draft release
         run: |
           TAG_NAME="v${{ inputs.version }}"
-          TITLE="OpenCRVS - $TAG_NAME"
-          NOTES="Release notes for version ${{ inputs.version }}"
-          git tag "$TAG_NAME"
-          git push origin "$TAG_NAME"
-          gh release create "$TAG_NAME" \
-            --title "$TITLE" \
-            --notes "$NOTES" \
-            --draft
+          if gh release view "$TAG_NAME" > /dev/null 2>&1; then
+            echo "Release $TAG_NAME already exists, skipping."
+          else
+            TITLE="OpenCRVS - $TAG_NAME"
+            NOTES="Release notes for version ${{ inputs.version }}"
+            git tag "$TAG_NAME"
+            git push origin "$TAG_NAME"
+            gh release create "$TAG_NAME" \
+              --title "$TITLE" \
+              --notes "$NOTES" \
+              --draft
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Delete the tag
         run: |
           TAG_NAME="v${{ inputs.version }}"
-          git tag -d "$TAG_NAME"
-          git push origin ":refs/tags/$TAG_NAME"
+          if git ls-remote --exit-code --tags origin "$TAG_NAME" > /dev/null 2>&1; then
+            git tag -d "$TAG_NAME" 2>/dev/null || true
+            git push origin ":refs/tags/$TAG_NAME"
+          else
+            echo "Tag $TAG_NAME does not exist on remote, skipping."
+          fi

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -36,12 +36,6 @@ on:
 jobs:
   release_workflow:
     runs-on: ubuntu-latest
-    # Explicitly declare required permissions as a safety net — org-level
-    # defaults may vary. contents: write for git push; pull-requests: write
-    # for gh pr create.
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       # Derive base_branch and target_branch from the version number.
       #   - patch (z > 0): base = release/<x>.<y>.<z-1>, target = master
@@ -91,6 +85,8 @@ jobs:
       # Skipped if the release branch was already created by a previous run.
       - name: Create release branch and update version numbers and CHANGELOG
         if: steps.check_branch.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -167,7 +163,7 @@ jobs:
             echo "PR release/${{ inputs.version }} → develop already exists (#$EXISTING_DEVELOP_PR), skipping."
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_PAT }}
 
       # Create a draft release so the release notes page exists immediately.
       # The tag is deleted right after: the publish workflow re-creates it when

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -62,12 +62,14 @@ jobs:
           echo "base_branch=$base_branch" >> $GITHUB_OUTPUT
 
       # Full history is required so yarn can traverse the commit graph.
+      # GH_TOKEN (PAT) is used instead of GITHUB_TOKEN so that git push has
+      # write access — GITHUB_TOKEN may be read-only depending on repo settings.
       - name: Checkout ${{ steps.get_base_branch.outputs.base_branch }}
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.get_base_branch.outputs.base_branch }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
 
       # Create the release branch, bump package.json, and update the
       # CHANGELOG — then push. The PRs are opened only after these commits
@@ -138,7 +140,7 @@ jobs:
             --title "chore: merge release v${{ inputs.version }} back to develop" \
             --body "Merge release branch back to develop to include version bump and changelog updates."
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
       # Create a draft release so the release notes page exists immediately.
       # The tag is deleted right after: the publish workflow re-creates it when
@@ -155,7 +157,7 @@ jobs:
             --notes "$NOTES" \
             --draft
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Delete the tag
         run: |


### PR DESCRIPTION
## Why

Same root cause as core: the workflow relied on `hoangvvo/gitflow-workflow-action@0.3.8` to handle branch creation and PR opening. This caused the same issues — auto-generated PR descriptions that had to be cleared afterward, no idempotency on re-runs, and the develop merge-back PR being opened from the release branch itself (polluting it with any conflict-resolution commits).

## What changes

- Replaced `hoangvvo/gitflow-workflow-action@0.3.8` with explicit shell steps for branch creation, version bumping, changelog update, and PR creation
- Removed the separate "Clear auto-generated PR comment" step — the PR body is now set correctly on creation
- Release branch creation is idempotent — skipped if the branch already exists
- PR creation is idempotent — checks for existing open PRs before creating (both master and develop)
- Introduces a dedicated `merge-back/release-<version>-to-develop` branch; the develop merge-back PR is opened from this branch so conflict-resolution commits never land on the release branch
- Draft release creation is idempotent — skipped if a release for that version already exists
- Tag deletion is safe on re-run — skipped if the tag no longer exists on remote

## How to test

1. Trigger via core's init-release workflow, or run manually from any branch that contains these changes, with a valid semver
2. Confirm: `release/<version>` is created with version-bump and changelog commits
3. Confirm: two PRs are opened — `release/<version> → master` and `merge-back/release-<version>-to-develop → develop` — both with the correct PR template body
4. Confirm: a draft release is created; the backing tag is deleted afterward
5. Re-run the workflow with the same version — all steps should complete cleanly with "already exists, skipping" messages
