### PR TITLE
fix: use administrative hierarchy as address field handlebars

### DIFF
--- a/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
@@ -175,12 +175,10 @@
         <tspan x="307" y="220.104">{{$join ", " ($lookup $declaration 'child.birthLocation.district') ($lookup $declaration 'child.birthLocation.province') ($lookup $declaration 'child.birthLocation.country')}}</tspan>
       {{else}}
         {{#ifCond ($lookup $declaration 'child.birthLocation.other') '!==' undefined }}
-        <tspan x="307" y="208.104">{{$or ($lookup $declaration 'child.birthLocation.other.district') ($lookup $declaration 'child.birthLocation.other.streetLevelDetails.district2')}}&#10;</tspan>
-        <tspan x="307" y="220.104">{{$or ($lookup $declaration 'child.birthLocation.other.streetLevelDetails.state') ($lookup $declaration 'child.birthLocation.other.province')}}, {{$lookup $declaration 'child.birthLocation.other.country'}}</tspan>
+        <tspan x="307" y="208.104">{{$lookup $declaration 'child.birthLocation.other.administrativeHierarchy'}}</tspan>
         {{else}}
           {{#ifCond ($lookup $declaration 'child.birthLocation.privateHome') '!==' undefined }}
-            <tspan x="307" y="208.104">{{$or ($lookup $declaration 'child.birthLocation.privateHome.district') ($lookup $declaration 'child.birthLocation.privateHome.streetLevelDetails.district2')}}&#10;</tspan>
-            <tspan x="307" y="220.104">{{$or ($lookup $declaration 'child.birthLocation.privateHome.streetLevelDetails.state') ($lookup $declaration 'child.birthLocation.privateHome.province')}}, {{$lookup $declaration 'child.birthLocation.privateHome.country'}}</tspan>
+            <tspan x="307" y="208.104">{{$lookup $declaration 'child.birthLocation.privateHome.administrativeHierarchy'}}</tspan>
           {{/ifCond}}
         {{/ifCond}}
       {{/ifCond}}
@@ -402,7 +400,7 @@
   <g clip-path="url(#clip17_946_2501)">
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
       font-size="8" letter-spacing="0px">
-      <tspan x="307" y="550.104">{{$join ", " ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.district") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.province") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.country")}}</tspan>
+      <tspan x="307" y="550.104">{{$join ", " ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.name") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.district") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.province") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.country")}}</tspan>
     </text>
   </g>
   <line x1="65" y1="556.5" x2="533" y2="556.5" stroke="#ECECEC" />

--- a/src/api/certificates/source/v2.birth-certificate.svg
+++ b/src/api/certificates/source/v2.birth-certificate.svg
@@ -207,12 +207,10 @@
         <tspan x="289.95" y="362.054">{{$join ", " ($lookup $declaration 'child.birthLocation.district') ($lookup $declaration 'child.birthLocation.province') ($lookup $declaration 'child.birthLocation.country')}}</tspan>
       {{else}}
         {{#ifCond ($lookup $declaration 'child.birthLocation.other') '!==' undefined }}
-          <tspan x="289.95" y="347.054">{{$or ($lookup $declaration 'child.birthLocation.other.district') ($lookup $declaration 'child.birthLocation.other.streetLevelDetails.district2')}}&#10;</tspan>
-          <tspan x="289.95" y="362.054">{{$or ($lookup $declaration 'child.birthLocation.other.streetLevelDetails.state') ($lookup $declaration 'child.birthLocation.other.province')}}, {{$lookup $declaration 'child.birthLocation.other.country'}}</tspan>
+          <tspan x="289.95" y="347.054">{{$lookup $declaration 'child.birthLocation.other.administrativeHierarchy'}}</tspan>
         {{else}}
           {{#ifCond ($lookup $declaration 'child.birthLocation.privateHome') '!==' undefined }}
-            <tspan x="289.95" y="347.054">{{$or ($lookup $declaration 'child.birthLocation.privateHome.district') ($lookup $declaration 'child.birthLocation.privateHome.streetLevelDetails.district2')}}&#10;</tspan>
-            <tspan x="289.95" y="362.054">{{$or ($lookup $declaration 'child.birthLocation.privateHome.streetLevelDetails.state') ($lookup $declaration 'child.birthLocation.privateHome.province')}}, {{$lookup $declaration 'child.birthLocation.privateHome.country'}}</tspan>
+            <tspan x="289.95" y="347.054">{{$lookup $declaration 'child.birthLocation.privateHome.administrativeHierarchy'}}</tspan>
           {{/ifCond}}
         {{/ifCond}}
       {{/ifCond}}

--- a/src/api/certificates/source/v2.death-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.death-certificate-certified-copy.svg
@@ -135,8 +135,7 @@
           <tspan x="312" y="306.104">{{$join ", " ($lookup $declaration 'eventDetails.deathLocation.district') ($lookup $declaration 'eventDetails.deathLocation.province') ($lookup $declaration 'eventDetails.deathLocation.country')}}</tspan>
         {{else}}
           {{#ifCond ($lookup $declaration 'eventDetails.deathLocationOther') '!==' undefined }}
-          <tspan x="312" y="294.104">{{$or ($lookup $declaration 'eventDetails.deathLocationOther.district') ($lookup $declaration 'eventDetails.deathLocationOther.streetLevelDetails.district2')}}&#10;</tspan>
-          <tspan x="312" y="306.104">{{$or ($lookup $declaration 'eventDetails.deathLocationOther.streetLevelDetails.state') ($lookup $declaration 'eventDetails.deathLocationOther.province')}}, {{$lookup $declaration 'eventDetails.deathLocationOther.country'}}</tspan>
+          <tspan x="312" y="294.104">{{$lookup $declaration 'eventDetails.deathLocationOther.administrativeHierarchy'}}</tspan>
           {{else}}
             {{#ifCond ($lookup $declaration 'deceased.address') '!==' undefined }}
             <tspan x="312" y="294.104">{{$or ($lookup $declaration 'deceased.address.district') ($lookup $declaration 'deceased.address.streetLevelDetails.district2')}}&#10;</tspan>
@@ -189,7 +188,7 @@
   </text>
   <g clip-path="url(#clip9_948_2918)">
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
-      <tspan x="312" y="404.104">{{$join ", " ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.district') ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.province') ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.country')}}</tspan>
+      <tspan x="312" y="404.104">{{$join ", " ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.name') ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.district') ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.province') ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.country')}}</tspan>
     </text>
   </g>
   <line x1="70" y1="410.5" x2="514" y2="410.5" stroke="#ECECEC" />

--- a/src/api/certificates/source/v2.death-certificate.svg
+++ b/src/api/certificates/source/v2.death-certificate.svg
@@ -128,8 +128,7 @@
           <tspan x="289.95" y="403.643">{{$join ", " ($lookup $declaration 'eventDetails.deathLocation.district') ($lookup $declaration 'eventDetails.deathLocation.province') ($lookup $declaration 'eventDetails.deathLocation.country')}}</tspan>
         {{else}}
           {{#ifCond ($lookup $declaration 'eventDetails.deathLocationOther') '!==' undefined }}
-          <tspan x="289.95" y="388.643">{{$or ($lookup $declaration 'eventDetails.deathLocationOther.district') ($lookup $declaration 'eventDetails.deathLocationOther.streetLevelDetails.district2')}}&#10;</tspan>
-          <tspan x="289.95" y="403.643">{{$or ($lookup $declaration 'eventDetails.deathLocationOther.streetLevelDetails.state') ($lookup $declaration 'eventDetails.deathLocationOther.province')}}, {{$lookup $declaration 'eventDetails.deathLocationOther.country'}}</tspan>
+          <tspan x="289.95" y="388.643">{{$lookup $declaration 'eventDetails.deathLocationOther.administrativeHierarchy'}}</tspan>
           {{else}}
             {{#ifCond ($lookup $declaration 'deceased.address') '!==' undefined }}
             <tspan x="289.95" y="388.643">{{$or ($lookup $declaration 'deceased.address.district') ($lookup $declaration 'deceased.address.streetLevelDetails.district2')}}&#10;</tspan>


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
