### PR TITLE
feat: Moved tilt helpers from helm-chart repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ package-lock.json
 # production
 build
 
+
+# NOTE: Only for OpenCRVS Core Team:
+# Sparce checkout from OpenCRVS core
+# Folder introduced in OpenCRVS v2.0 to allow pushing changes to helm charts
+.opencrvs-core-charts
+
 # misc
 .DS_Store
 .env

--- a/.tiltignore
+++ b/.tiltignore
@@ -1,0 +1,1 @@
+.opencrvs-core-charts/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"> <a href="https://www.opencrvs.org"><img src="https://i.imgur.com/W7ULmox.png" title="source: imgur.com" / style="max-width:100%;"width="72" height="72"></a>
 </p>
-<h3 align="center">Farajaland country configuration repository</h3>
+<h1 align="center">Country configuration template repository</h1>
 <p align="center">An example configuration for OpenCRVS using a fictional country called Farajaland.
 <br>
 <a href="https://github.com/opencrvs/opencrvs-core/issues">Report an issue</a>  ·  <a href="https://community.opencrvs.org">Join our community</a>  ·  <a href="https://documentation.opencrvs.org">Read our documentation</a>  ·  <a href="https://www.opencrvs.org">www.opencrvs.org</a></p>
@@ -10,134 +10,276 @@
 
 - [What is this module for?](#what-is-this-module-for)
 - [How do I run the module alongside the OpenCRVS core?](#how-do-i-run-the-module-alongside-the-opencrvs-core)
-- [What is in the Farajaland configuration module repository?](#what-is-in-the-farajaland-configuration-module-repository)
+- [Userful information](#userful-information)
+- [What is in the Countryconfig configuration module repository?](#what-is-in-the-countryconfig-configuration-module-repository)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <br>
 <br>
+
 **This is the fictional country "Farajaland" OpenCRVS country configuration repository for [OpenCRVS](https://github.com/opencrvs/opencrvs-core) You must fork this for your own country.**
 
 <a href="https://documentation.opencrvs.org/setup/3.-installation/3.2-set-up-your-own-country-configuration">Read our documentation</a> to learn how to set up your own country configuration using this repo as an example.
 
-## What is this module for?
+# What is this module for?
 
-This is an example country configuration package for the OpenCRVS core. OpenCRVS requires a country configuration in order to run.
+OpenCRVS requires a country configuration in order to run. This is an example country configuration package for the OpenCRVS core.
 
 OpenCRVS is designed to be highly configurable for your country needs. It achieves this by seeding reference data that it needs from this module and exposing APIs for certain business critical operations.
 
 This module also provides a logical location where you may wish to store the code and run the servers for any custom API integrations, extension modules and innovations to OpenCRVS.
 
-## How do I run the module alongside the OpenCRVS core?
+# How do I run the module alongside the OpenCRVS core?
 
-1. Ensure that you are running [OpenCRVS Core](https://github.com/opencrvs/opencrvs-core).
+OpenCRVS Core is not run directly from source in this setup. Instead, Core services are deployed as a Helm chart, and Core Docker images are pulled from the configured image tag.
 
-**If you successfully ran the `bash setup.sh` script in OpenCRVS Core you already have this module checked out, the dependencies are installed, the Farajaland database is populated and you can just run the following command.**
 
-2. `yarn dev`
+## Prerequisites
+
+### Hardware requirements
+
+Recommended minimum:
+
+- 16 GB RAM
+- 8 CPUs
+- 100 GB free disk space
+
+### Software requirements
+
+| Tool | Description |
+| --- | --- |
+| Kubernetes | Local Kubernetes cluster. Minikube is recommended for Linux. Docker Desktop Kubernetes is recommended for macOS and Windows. |
+| Docker | Required for building the countryconfig image locally. |
+| kubectl | Kubernetes command-line tool. |
+| Helm | Used by Tilt to render and deploy OpenCRVS Helm charts. |
+| Tilt | Used to manage the local development environment. |
+| Git | Used by the Tiltfile to clone OpenCRVS Core charts. |
+
+
+## Development environment setup
+
+### Start local Kubernetes cluster (Minikube)
+
+Minikube is recommended for Linux users.
+
+Start Minikube with enough resources, recommended values are 8 CPU cores and 12G RAM. If Minikube was already running before changing these values, recreate it:
+
+```bash
+minikube start \
+  --driver=docker \
+  --cpus=8 \
+  --memory=12g \
+  --ports=80:30080
+```
+
+Make sure your kubectl context points to Minikube:
+```
+kubectl config current-context
+```
+Expected context:
+```
+minikube
+```
+
+> [!NOTE]
+> Other local Kubernetes engines may also work, for example:
+> - OrbStack
+> - kind
+> - k3d
+> - MicroK8s
+>
+> If you use a different Kubernetes engine, make sure that:
+> - Docker image builds are available to the cluster
+> - LoadBalancer or NodePort access is configured
+> - opencrvs.localhost can resolve to the local ingress endpoint
+
+### Start OpenCRVS
+
+Clone this repository:
+```
+git clone https://github.com/opencrvs/opencrvs-countryconfig.git
+cd opencrvs-countryconfig
+```
+
+Start the local environment:
+```
+tilt up
+```
+Open the Tilt UI:
+```
+http://localhost:10350
+```
+Wait until the main resources are running.
+
+Then run the data seed task from the Tilt UI:
+1. Open http://localhost:10350
+2. Find the `2.Data-tasks` section
+3. Run the `seed-data` or `clean-&-seed` resource
+4. Wait until the job completes
+
+Open OpenCRVS: http://opencrvs.localhost
 
 Thats it! 🎉
 
-## Database Management
+### Configuration
 
-The country configuration includes scripts for managing analytics and metabase databases during development and deployment.
+The Tiltfile supports the following environment variables.
 
-### Development Database Management
+- `OPENCRVS_CORE_IMAGE_TAG`: Defines the OpenCRVS Core Docker image tag used by the Helm chart.
+- `OPENCRVS_CORE_REF`: Defines the OpenCRVS Core Git branch or tag used to fetch Helm charts, use any release/2.0.X branch or tag from https://github.com/opencrvs/opencrvs-core
 
-- `yarn db:clear:all` - Clears all development databases including:
-  - PostgreSQL analytics schema and data
-The script is designed to be extended by country implementations to clear additional custom databases as needed.
 
-### Production Database Management
+The Tiltfile performs a sparse checkout of the OpenCRVS Core repository and only downloads the charts directory. You still be able to modify changes and create PRs in Core repository.
 
-For deployed environments, analytics data is cleared when the "reset data" pipeline is triggered, which uses the `infrastructure/clear-all-data.sh` script. This script now includes clearing of:
-- **Metabase analytics database** - Both the PostgreSQL analytics schema and Metabase H2 configuration database
+# Userful information
 
-## What is in the Farajaland configuration module repository?
+## How the Tilt setup works
+
+Tilt performs the following actions:
+
+1. Clones OpenCRVS Core charts into a local .opencrvs-core-charts directory.
+2. Builds the countryconfig image locally: `opencrvs/ocrvs-countryconfig:local`
+3. Builds the countryconfig assets image: `opencrvs/ocrvs-countryconfig:local-assets`
+4. Deploys Components into namespaces:
+   - Traefik: `traefik`
+   - OpenCRVS dependencies: `opencrvs-deps-dev`
+   - OpenCRVS Core: `opencrvs-dev`
+5. Overrides the Helm chart countryconfig image values so that Core uses the locally built countryconfig image.
+6. Disables automatic Helm install data seeding and exposes data jobs through Tilt instead.
+
+You can inspect resources with:
+```
+kubectl get pods -n opencrvs-deps-dev
+kubectl get pods -n opencrvs-dev
+```
+
+## Live update behavior
+
+Tilt builds the countryconfig image locally and watches selected files for changes.
+
+Source code changes under `srv/` are synced into the running container using Tilt live update.
+
+Changes to dependency or image build files trigger a full rebuild instead, for example:
+```
+package.json
+yarn.lock
+Dockerfile
+```
+
+## Development Database Management
+
+Development database tasks are available from the Tilt UI.
+
+Open the Tilt dashboard: http://localhost:10350
+
+Then go to: `2.Data-tasks`
+
+Available tasks:
+
+| Task           | Description                                                                                                  |
+| -------------- | ------------------------------------------------------------------------------------------------------------ |
+| `data-cleanup` | Clears existing local development data.                                                                      |
+| `data-seed`    | Seeds the local environment with development/demo data.                                                      |
+| `clean-&-seed` | Runs cleanup first, then seeds the environment again. Use this when you want to reset local data completely. |
+
+### Clean up the local environment
+
+Stop Tilt and remove deployed resources:
+```
+tilt down
+```
+
+Remove minikube cluster:
+```
+minikube delete
+```
+
+
+# What is in the Countryconfig configuration module repository?
 
 One of the key dependencies and enablers for OpenCRVS is country configuration and a reference data source. This source is bespoke for every implementing nation. If you would like to create your own country implementation, we recommend that you duplicate this repository and use it as a template. So what does it contain?
 
-1. This repository contains:
+- The DEPRECATED [infrastructure](infrastructure) folder containing all Ansible server configuration files, deployment scripts and docker-compose files allowing you to configure OpenCRVS to run on any infrastructure stack without requiring a fork in opencrvs-core.
 
-- The "infrastructure" folder containing all Ansible server configuration files, deployment scripts and docker-compose files allowing you to configure OpenCRVS to run on any infrastructure stack without requiring a fork in opencrvs-core.
+- The [src](src) folder contains the code required to run the countryconfig microservice apis, configure your registration form and seed your country implementation with reference data. Essentially this repository could be re-written from NodeJS into Java or another language as long as the service provided the same API endpoints and served the same files as listed below. For more information please [read this section of the documentation.](https://documentation.opencrvs.org/setup/3.-installation/3.2-set-up-your-own-country-configuration)
 
-- The [src](https://github.com/opencrvs/opencrvs-countryconfig/master/src) folder contains the code required to run the countryconfig microservice apis, configure your registration form and seed your country implementation with reference data. Essentially this repository could be re-written from NodeJS into Java or another language as long as the service provided the same API endpoints and served the same files as listed below. For more information please [read this section of the documentation.](https://documentation.opencrvs.org/setup/3.-installation/3.2-set-up-your-own-country-configuration)
+- The [tilt](tilt) folder and [Tiltfile](Tiltfile) define the local Kubernetes development environment. Tilt is responsible for deploying OpenCRVS dependencies and Core services using Helm charts, building the local countryconfig image, configuring live updates and exposing operational tasks such as database cleanup and data seeding through the Tilt UI.
 
 - Postman collections demonstrate how to interoperate with OpenCRVS.  You can build any custom integration into OpenCRVS in this repository if you need to.
 
-- The following business critical API and hosted file endpoints:
+- Business critical API and hosted file endpoints (Data seeding)
 
 **Data seeding**
 
 When the OpenCRVS Core servers start up with un-seeded databases they call the following endpoints in order to populate the databases accordingly:
 
 1. `GET /application-config`
-
-- Configures general application settings
+   - Configures general application settings
 
 2. `GET /users`
 
-- Configures at a minimum, a default National System Admin user for the application.  More users can be created for demonstration purposes or in a batch.  The passwords entered are required to be changed by the user on first login.
+   - Configures at a minimum, a default National System Admin user for the application.  More users can be created for demonstration purposes or in a batch.  The passwords entered are required to be changed by the user on first login.
 
 3. `GET /roles`
 
-- Seeds the internal role titles used by your civil registration orgnisation mapping to the available OpenCRVS user types.
+   - Seeds the internal role titles used by your civil registration orgnisation mapping to the available OpenCRVS user types.
 
 4. `GET /locations`
 
-- Seeds the administrative structure of your country following the Humdata standard
+   - Seeds the administrative structure of your country following the Humdata standard
 
 5. `GET /statistics`
 
-- Applies historical population and crude birth rates disaggregated by gender to your administrative structure.  This data ensures that your registration completeness rates are accuratley calculated.
+   - Applies historical population and crude birth rates disaggregated by gender to your administrative structure.  This data ensures that your registration completeness rates are accuratley calculated.
 
 6. `GET /certificates`
 
-- Configures the available event certificate SVG files. These files can be updated in future via the National System Administrator user interface.
+   - Configures the available event certificate SVG files. These files can be updated in future via the National System Administrator user interface.
 
 **Business critical APIs**
 
 1. `GET /forms`
 
-- Configures versioned registration forms for OpenCRVS vital events as JSON.
+   - Configures versioned registration forms for OpenCRVS vital events as JSON.
 
 2. `GET /content/{application}`
 
-- Returns all language content as JSON
+   - Returns all language content as JSON
 
 3. `POST /notification`
 
-- Receives notification payloads from OpenCRVS Core in order to transmit messages to staff and customers based on SMS, Email or other customisable method.
+   - Receives notification payloads from OpenCRVS Core in order to transmit messages to staff and customers based on SMS, Email or other customisable method.
 
 4. `GET /crude-death-rate` (Deprecation warning!)
 
-- OpenCRVS "metrics" microservice receives a global crude death rate constant from this endpoint in order to calculate death registration completeness rates.  Unlike for crude birth rate, most countries do not have a statistic by administrative area disaggregated by gender for death rate.  This API endpoint can be considered as tehcnical debt and will likely be replaced by a config setting in the `GET /application-config` response.
+   - OpenCRVS "metrics" microservice receives a global crude death rate constant from this endpoint in order to calculate death registration completeness rates.  Unlike for crude birth rate, most countries do not have a statistic by administrative area disaggregated by gender for death rate.  This API endpoint can be considered as tehcnical debt and will likely be replaced by a config setting in the `GET /application-config` response.
 
 5. `POST /event-registration`
 
-- This synchronous API exists as it is the final step before legal registration of an event.  Some countries desire to create multiple identifiers for citizens at the point of registration using external systems. Some countries wish to integrate with another legacy system just before registration.  A synchronous 3rd party system can be integrated at this point. Some countries wish to customise the registration number format.  The registration number can be created at this point. Some countries use sequential numbering for registration numbers.  While it is possible to create that functionality here, we strongly discourage that approach and advise our unique alphanumeric ID format using the Tracking ID. The reason is, under times of high traffic, it is likely that sequential number generation can slow the performance of the service.  In a such a case a queue could be implemented here.
+   - This synchronous API exists as it is the final step before legal registration of an event.  Some countries desire to create multiple identifiers for citizens at the point of registration using external systems. Some countries wish to integrate with another legacy system just before registration.  A synchronous 3rd party system can be integrated at this point. Some countries wish to customise the registration number format.  The registration number can be created at this point. Some countries use sequential numbering for registration numbers.  While it is possible to create that functionality here, we strongly discourage that approach and advise our unique alphanumeric ID format using the Tracking ID. The reason is, under times of high traffic, it is likely that sequential number generation can slow the performance of the service.  In a such a case a queue could be implemented here.
 
 6. `GET /validators.js` & `GET /conditionals.js`
 
-- Registration form JSON "Validators" and "Conditionals" refer to in-built OpenCRVS Core JavaScript form validation and conditional methods. Custom methods can be exposed to OpenCRVS Core via these endpoints.
+   - Registration form JSON "Validators" and "Conditionals" refer to in-built OpenCRVS Core JavaScript form validation and conditional methods. Custom methods can be exposed to OpenCRVS Core via these endpoints.
 
 7. `GET /login-config.js` & `GET /client-config.js`
 
-- JS configuration settings files that the clients require in order to initialise, set up languages, track any errors and find essential services. 2 files for development and production environments must be available in each case.
+   - JS configuration settings files that the clients require in order to initialise, set up languages, track any errors and find essential services. 2 files for development and production environments must be available in each case.
 
 8. `GET /content/country-logo`
 
-- The country logo is loaded into HTML emails so must be hosted
+   - The country logo is loaded into HTML emails so must be hosted
 
 9. `GET /content/map.geojson`
 
-- A map of the country in GeoJSON must be hosted as it is loaded into OpenCRVS Core Metabase Dashboards as a UI component
+   - A map of the country in GeoJSON must be hosted as it is loaded into OpenCRVS Core Metabase Dashboards as a UI component
 
 10. `GET /ping`
 
-- A service health check endpoint used for 3rd party application stack monitoring
+   - A service health check endpoint used for 3rd party application stack monitoring
 
 **<a href="https://documentation.opencrvs.org">Read our documentation</a> in order to learn how to make your own country configuration!**
 
-## Action Confirmation
+# Action Confirmation
 
 The Action Confirmation is a feature of OpenCRVS that allows for asynchronous confirmation of event actions. See documentation here: [Action Confirmation](./src/api/action-confirmation.md)

--- a/Tiltfile
+++ b/Tiltfile
@@ -3,30 +3,46 @@
 # For more information about variables, please check:
 # https://github.com/opencrvs/infrastructure/blob/develop/Tiltfile
 
-# Helm charts branch or tag:
-helm_chart_branch_or_tag = "develop"
-
 # OpenCRVS core images tag:
 # For releases it's ok to keeps same as branch_or_tag
-core_images_tag = "develop"
+core_images_tag = os.getenv("OPENCRVS_CORE_IMAGE_TAG", "v2.0.0-beta")
+
+# FIXME: Put release version
+core_ref = os.getenv("OPENCRVS_CORE_REF", "add-helm-charts")
 
 # Build countryconfig image in local registry (use any name and tag you want)
 countryconfig_image_name="opencrvs/ocrvs-countryconfig"
 countryconfig_image_tag="local"
 
-load('ext://git_resource', 'git_checkout')
 
-charts_repo_url = "git@github.com:opencrvs/opencrvs-helm-charts.git#{}".format(helm_chart_branch_or_tag)
+# Internal variable for helm charts checkout
+core_charts_dir = ".opencrvs-core-charts"
 
-if not os.path.exists('../opencrvs-helm-charts'):
-  print("Cloning OpenCRVS Helm charts from {}...".format(charts_repo_url))
-  git_checkout(charts_repo_url, '../opencrvs-helm-charts')
-else:
-  print("⚠️ Skipping clonning {}, folder {} already exists. Use `git` CLI to update repository".format(charts_repo_url, '../opencrvs-helm-charts'))
-if not os.path.exists('../opencrvs-helm-charts/charts/dependencies') or not os.path.exists('../opencrvs-helm-charts/charts/opencrvs-services'):
+core_repo_url = 'https://github.com/opencrvs/opencrvs-core.git'
+
+print("Cloning OpenCRVS Helm charts from {}...".format(core_repo_url))
+local("""
+  rm -rf {core_charts_dir}
+  git clone \
+    --depth 1 \
+    --filter=blob:none \
+    --sparse \
+    --branch {core_ref} \
+    {core_repo_url} \
+    {core_charts_dir}
+
+  cd {core_charts_dir}
+  git sparse-checkout set charts
+""".format(
+  core_ref=core_ref,
+  core_charts_dir=core_charts_dir,
+  core_repo_url=core_repo_url
+))
+
+if not os.path.exists('{core_charts_dir}/charts/dependencies'.format(core_charts_dir=core_charts_dir)) or not os.path.exists('{core_charts_dir}/charts/opencrvs-services'.format(core_charts_dir=core_charts_dir)):
   fail('Something went wrong while cloning infrastructure repository!')
 
-load('../opencrvs-helm-charts/tilt/opencrvs.tilt', 'setup_opencrvs')
+load('./tilt/opencrvs.tilt', 'setup_opencrvs')
 
 # Build countryconfig image
 docker_build(
@@ -60,12 +76,13 @@ docker_build("{0}:{1}-assets".format(countryconfig_image_name, countryconfig_ima
               only=[
                 'infrastructure/metabase',
                 'infrastructure/postgres',
+                'infrastructure/deployment',
                 './Dockerfile.assets'
               ]
 )
 
 setup_opencrvs(
-    opencrvs_chart_repo='../opencrvs-helm-charts',
+    opencrvs_chart_repo=core_charts_dir,
     core_images_tag=core_images_tag,
     countryconfig_image_name=countryconfig_image_name,
     countryconfig_image_tag=countryconfig_image_tag,

--- a/tilt/clear-all-data.ps1
+++ b/tilt/clear-all-data.ps1
@@ -1,0 +1,42 @@
+Write-Host "Running data cleanup"
+
+$Namespace = "opencrvs-dev"
+
+$Jobs = @(
+    "data-cleanup",
+    "postgres-on-deploy",
+    "influxdb-on-deploy",
+    "data-migration",
+    "data-migration-analytics",
+    "data-seed",
+    "elasticsearch-reindex"
+)
+
+foreach ($Job in $Jobs) {
+    kubectl delete job $Job -n $Namespace --ignore-not-found
+
+    if ($Job -eq "data-seed") {
+        kubectl delete pod -l app=events -n $Namespace
+    }
+
+    tilt trigger $Job
+
+    Start-Sleep -Seconds 10
+
+    kubectl wait `
+        --for=condition=complete `
+        --timeout=300s `
+        "job/$Job" `
+        -n $Namespace
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Job $Job failed or timed out"
+        exit 1
+    }
+
+    Write-Host "======================== Job $Job completed ==============================="
+
+    kubectl logs "job/$Job" -n $Namespace
+}
+
+Write-Host "Cleanup was successful"

--- a/tilt/clear-all-data.sh
+++ b/tilt/clear-all-data.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "Running data cleanup"
+
+jobs=(
+  "data-cleanup"
+  'postgres-on-deploy'
+  'influxdb-on-deploy'
+  'data-migration'
+  'data-migration-analytics'
+  'data-seed'
+  'elasticsearch-reindex'
+)
+
+for job in "${jobs[@]}"; do
+    kubectl delete job $job -n opencrvs-dev --ignore-not-found
+    if [ "$job" == "data-seed" ]; then
+      kubectl delete pod -lapp=events -n opencrvs-dev
+    fi
+    tilt trigger $job
+    sleep 10
+    kubectl wait --for=condition=complete --timeout=300s job/$job -n opencrvs-dev
+    echo "======================== Job $job completed ==============================="
+    kubectl logs job/$job -n opencrvs-dev
+done
+
+echo "Cleanup was successful"

--- a/tilt/common.tilt
+++ b/tilt/common.tilt
@@ -1,0 +1,114 @@
+############################################################
+# What common Tiltfile does?:
+# - Traefik deployment
+# - Group resources by label on UI: http://localhost:10350/
+
+########################################################
+# Load extensions for namespace and helm operations
+load('ext://namespace', 'namespace_create', 'namespace_inject')
+load('ext://helm_resource', 'helm_resource', 'helm_repo')
+
+
+secret_settings(disable_scrub=True)
+########################################################
+# Traefik Deployment
+print("🚀 Deploying traefik...")
+namespace_create('traefik')
+traefik_tilt_label = '5.Traefik'
+# Install Traefik GW
+helm_repo('traefik-repo', 'https://traefik.github.io/charts', labels=[traefik_tilt_label])
+helm_resource(
+  'traefik', 'traefik-repo/traefik', namespace='traefik', resource_deps=['traefik-repo'],
+  flags=['--values=./examples/traefik/values.yaml'])
+
+# OpenCRVS application has traefik CRDs IngressRoute
+# and Middleware, so we need to add traefik as dependency
+# to all workloads that use them
+traefik_deps = [
+  'auth', 
+  'client',
+  'countryconfig',
+  'events',
+  'gateway',
+  'login',
+  'minio'
+]
+k8s_resource("traefik", labels=[traefik_tilt_label])
+# Add labels to traefik resources
+traefik_ingress_objects = ["{}-route:ingressroute".format(dep) for dep in traefik_deps]
+traefik_middleware_objects = ["sts-and-basic-response-headers:middleware", "enable-compression:middleware", "block-internal-routes:middleware"]
+k8s_resource(
+  objects=traefik_ingress_objects,
+  new_name='traefik-ingress-routes',
+  resource_deps=['traefik'],
+  labels=[traefik_tilt_label]
+)
+k8s_resource(
+  objects=traefik_middleware_objects,
+  new_name='traefik-middleware',
+  resource_deps=['traefik'],
+  labels=[traefik_tilt_label]
+)
+
+######################################################
+# Add labels to resources to OpenCRVS services
+tilt_label = '4.Dependencies'
+dependencies = [
+  'elasticsearch',
+  'mongodb',
+  'minio', 
+  'influxdb', 
+  'redis',
+  'postgres',
+  # 'postgres-on-deploy',
+  # FIXME: both resources are present only if security is enabled
+  # 'elasticsearch-on-deploy',
+  # 'mongo-on-deploy',
+]
+
+for workload in dependencies:
+  k8s_resource(workload, labels=[tilt_label])
+
+######################################################
+# Add labels to resources to OpenCRVS services
+tilt_label = '1.OpenCRVS'
+
+opensrvs_predeploy_jobs = [
+  'postgres-on-deploy',
+  # FIXME: works only if security is enabled
+  # 'mongo-on-deploy',
+  # 'elasticsearch-on-deploy',
+  'influxdb-on-deploy',
+  'data-migration',
+  'data-migration-analytics',
+  'data-migration-legacy',
+]
+
+opensrvs_services = [
+  'auth',
+  'client',
+  'countryconfig',
+  'documents', 
+  'events',
+  'gateway',
+  'login',
+  'user-mgnt'
+]
+
+opensrvs_postdeploy_jobs = [
+  'elasticsearch-reindex',
+]
+
+job_label = '3.Jobs'
+previous_jobs = []
+for job in opensrvs_predeploy_jobs:
+  if previous_jobs:
+    k8s_resource(job, labels=[job_label], resource_deps=dependencies + previous_jobs)
+  else:
+    k8s_resource(job, labels=[job_label], resource_deps=dependencies + previous_jobs)
+  previous_jobs.append(job)
+
+for workload in opensrvs_services:
+  k8s_resource(workload, labels=[tilt_label], resource_deps=dependencies + opensrvs_predeploy_jobs)
+for job in opensrvs_postdeploy_jobs:
+  k8s_resource(job, labels=[job_label], resource_deps=opensrvs_services)

--- a/tilt/examples/dependencies/values-azure.yaml
+++ b/tilt/examples/dependencies/values-azure.yaml
@@ -1,0 +1,33 @@
+# Will be provided as variable at helm install time
+# hostname: opencrvs.localhost
+
+ingress:
+  ssl_enabled: false
+
+storage_type: pvc
+
+# FIXME: Decide what to do with monitoring
+monitoring:
+  enabled: true
+
+backup:
+  enabled: false
+
+restore:
+  enabled: false
+
+mongodb:
+  use_default_credentials: false
+
+postgres:
+  enabled: false
+
+elasticsearch:
+  use_default_credentials: false
+
+minio:
+  enabled: false
+  use_default_credentials: false
+
+redis:
+  enabled: false

--- a/tilt/examples/dependencies/values-secure.yaml
+++ b/tilt/examples/dependencies/values-secure.yaml
@@ -1,0 +1,19 @@
+hostname: opencrvs.localhost
+
+ingress:
+  ssl_enabled: false
+
+redis:
+  auth_mode: acl
+
+minio:
+  use_default_credentials: false
+
+elasticsearch:
+  use_default_credentials: false
+
+mongodb:
+  use_default_credentials: false
+
+postgres:
+  use_default_credentials: false

--- a/tilt/examples/dependencies/values.yaml
+++ b/tilt/examples/dependencies/values.yaml
@@ -1,0 +1,4 @@
+hostname: opencrvs.localhost
+
+ingress:
+  ssl_enabled: false

--- a/tilt/examples/opencrvs-services/values-azure.yaml
+++ b/tilt/examples/opencrvs-services/values-azure.yaml
@@ -1,0 +1,76 @@
+# All OpenCRVS services will be available under domain:
+# hostname: opencrvs.localhost
+
+# Access OpenCRVS services at http://opencrvs.localhost
+# If SSL is enabled, You need to accept SSL Certificate on localhost for multiple endpoints:
+# - login
+# - register
+# - countryconfig
+# - config
+# - client
+# - ...
+# That makes it easier to test the application locally without SSL
+# On local environment SSL is disabled by default:
+ingress:
+  ssl_enabled: false
+
+# On local environment services are exposed at NodePort as well and are available from Tilt
+# To access service you need to click on the service name in Tilt UI:
+service_type: NodePort
+
+# Horizontal Pod Autoscaler (HPA) configuration:
+# Disabled by default for local environment.
+hpa:
+  enabled: false
+
+# Pod Disruption Budget (PDB) configuration:
+# Disabled by default for local environment.
+pdb:
+  enabled: false
+
+elasticsearch:
+  auth_mode: auto
+  # Copy  elasticsearch-admin-user from opencrvs-deps-qa namespace into opencrvs-qa namespace
+  host: elasticsearch.opencrvs-deps-qa.svc.cluster.local
+  admin_user_secret_name: elasticsearch-admin-user
+
+# With Azure Storage we need to create secret minio-opencrvs-users
+# https://github.com/opencrvs/opencrvs-helm-charts/tree/develop/charts/opencrvs-services#minio-secret-miniousers_secret
+minio:
+  auth_mode: use_secret
+  # Copy minio-opencrvs-users from opencrvs-deps-qa namespace into opencrvs-qa namespace
+  host: minio-0.minio.opencrvs-deps-qa.svc.cluster.local
+  users_secret: minio-opencrvs-users
+
+mongodb:
+  auth_mode: auto
+  # Copy mongodb-admin-user from opencrvs-deps-qa namespace into opencrvs-qa namespace
+  admin_user_secret_name: mongodb-admin-user
+  host: mongodb-0.mongodb.opencrvs-deps-qa.svc.cluster.local
+
+redis:
+  auth_mode: use_secret
+  # Create redis-opencrvs-users secret in opencrvs-qa namespace with Redis credentials
+  # Credentials need to be taken fro Azure Cache for Redis instance
+  # Use secret specification: https://github.com/opencrvs/opencrvs-helm-charts/tree/develop/charts/opencrvs-services#redis-secret-redisusers_secret
+  users_secret: redis-opencrvs-users
+  host: <define redis host/endpoint here>
+  port: <define redis port here>
+
+postgres:
+  auth_mode: auto
+  host: <define postgres host/endpoint here>
+  port: <define postgres port here>
+  # Create postgres-admin-user secret in opencrvs-qa namespace with Postgres credentials
+  # Credentials need to be taken from Azure Database for PostgreSQL instance
+  # Use secret specification:
+  # https://github.com/opencrvs/opencrvs-helm-charts/tree/develop/charts/opencrvs-services#postgres-secrets
+
+image:
+  # Use latest version from https://github.com/opencrvs/opencrvs-core/actions/workflows/build-images-from-branch.yml
+  tag: 9b463e3
+
+countryconfig:
+  image:
+    repository: <your dockerhub account>/<image name>
+    tag: <image tag>

--- a/tilt/examples/opencrvs-services/values-secure.yaml
+++ b/tilt/examples/opencrvs-services/values-secure.yaml
@@ -1,0 +1,46 @@
+# All OpenCRVS services will be available under domain:
+hostname: opencrvs.localhost
+
+# Access OpenCRVS services at http://opencrvs.localhost
+# If SSL is enabled, You need to accept SSL Certificate on localhost for multiple endpoints:
+# - login
+# - register
+# - countryconfig
+# - config
+# - client
+# - ...
+# That makes it easier to test the application locally without SSL
+# On local environment SSL is disabled by default:
+ingress:
+  ssl_enabled: false
+
+# On local environment services are exposed at NodePort as well and are available from Tilt
+# To access service you need to click on the service name in Tilt UI:
+service_type: NodePort
+
+elasticsearch:
+  auth_mode: auto
+
+minio:
+  auth_mode: auto
+# Horizontal Pod Autoscaler (HPA) configuration:
+# Disabled by default for local environment.
+hpa:
+  enabled: false
+
+# Pod Disruption Budget (PDB) configuration:
+# Disabled by default for local environment.
+pdb:
+  enabled: false
+
+mongodb:
+  auth_mode: auto
+
+postgres:
+  auth_mode: auto
+
+redis:
+  auth_mode: use_secret
+
+image:
+  tag: develop

--- a/tilt/examples/opencrvs-services/values.yaml
+++ b/tilt/examples/opencrvs-services/values.yaml
@@ -1,0 +1,34 @@
+ingress:
+  ssl_enabled: false
+
+env:
+  OPENCRVS_ENVIRONMENT: development
+
+credentials:
+  super_user_password: password
+
+# OpenCRVS core image tag:
+platform:
+  tag: v2.0.0-beta
+
+countryconfig:
+  image:
+    tag: v1.9.11
+
+# Horizontal Pod Autoscaler (HPA) configuration:
+# Disabled by default for local environment.
+hpa:
+  enabled: false
+
+# Pod Disruption Budget (PDB) configuration:
+# Disabled by default for local environment.
+pdb:
+  enabled: false
+
+# Dashboards is disabled by default to allow easy deployment on Apple Silicon
+# If you are using x86 device, feel free to enable:
+dashboards:
+  enabled: false
+
+# Expose services on Node port
+service_type: NodePort

--- a/tilt/examples/traefik/values.yaml
+++ b/tilt/examples/traefik/values.yaml
@@ -1,0 +1,35 @@
+# Overwriting https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml
+namespaceOverride: "traefik"
+logs:
+  general:
+    # "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "PANIC"
+    level: "INFO"
+    # format: "common" # For local environment
+    format: "json" # For server environment
+  access:
+    # -- To enable access logs
+    enabled: true
+ingressRoute:
+  dashboard:
+    enabled: false
+# Be explicit that we only use CRDs, not ingress/gw support
+providers: 
+  kubernetesCRD:
+    enabled: true
+  kubernetesIngress:
+    enabled: true
+  kubernetesGateway:
+    enabled: false
+service:
+  enabled: true
+  single: false
+  type: NodePort
+
+ports:
+  web:
+    port: 8000
+    hostPort: 80
+    protocol: TCP
+    nodePort: 30080
+
+tlsStore: {}

--- a/tilt/lib.tilt
+++ b/tilt/lib.tilt
@@ -1,0 +1,85 @@
+def copy_secrets(dependencies_namespace, opencrvs_namespace):
+
+    secrets_to_copy = [
+        "elasticsearch-admin-user",
+        "redis-opencrvs-users",
+        "minio-opencrvs-users",
+        "mongodb-admin-user",
+        "postgres-admin-user",
+    ]
+    k8s_resource(
+        new_name="deps-secrets",
+        objects=["{}:secret".format(secret) for secret in secrets_to_copy],
+        labels=['3.Dependencies']
+    )
+    local_resource(
+      "copy-secrets",
+      cmd="""kubectl get secret {2} -n {0} -o yaml \
+             | sed "s#namespace: {0}#namespace: {1}#" | grep -v 'resourceVersion\\|uid\\|creationTimestamp' \
+             | kubectl apply -n {1} -f -""".format(dependencies_namespace, opencrvs_namespace, " ".join(secrets_to_copy)),
+      resource_deps=["deps-secrets"],
+      labels=['2.Data-tasks'])
+
+
+def data_cleanup(
+    opencrvs_namespace,
+    opencrvs_configuration_file,
+    core_images_tag,
+    countryconfig_image_name,
+    countryconfig_image_tag,
+    opencrvs_tools_chart_path
+):
+    job_yaml = local("""
+            helm template {opencrvs_tools_chart_path} \
+                --namespace {opencrvs_namespace} \
+                -f {opencrvs_configuration_file} \
+                --set image.tag={core_images_tag} \
+                --set data_cleanup.enabled=true \
+                --set countryconfig.image.name={countryconfig_image_name} \
+                --set countryconfig.image.tag={countryconfig_image_tag} \
+                --show-only templates/data-cleanup-job.yaml
+        """.format(
+            opencrvs_namespace=opencrvs_namespace,
+            opencrvs_configuration_file=opencrvs_configuration_file,
+            core_images_tag=core_images_tag,
+            countryconfig_image_name=countryconfig_image_name,
+            countryconfig_image_tag=countryconfig_image_tag,
+            opencrvs_tools_chart_path=opencrvs_tools_chart_path
+        ),
+        quiet=True
+    )
+
+    k8s_yaml(job_yaml)
+    k8s_resource(
+        'data-cleanup',
+        labels=['2.Data-tasks'],
+        auto_init=False
+    )
+
+def seed_data(
+    opencrvs_namespace,
+    opencrvs_configuration_file,
+    core_images_tag,
+    countryconfig_image_name,
+    countryconfig_image_tag,
+    opencrvs_tools_chart_path
+):
+    job_yaml = local("""
+      helm template -f {opencrvs_configuration_file} \
+        --set image.tag={core_images_tag} \
+        --set data_seed.enabled=true -s templates/data-seed-job.yaml --namespace {opencrvs_namespace} {opencrvs_tools_chart_path}
+      """.format(
+            opencrvs_namespace=opencrvs_namespace,
+            opencrvs_configuration_file=opencrvs_configuration_file,
+            core_images_tag=core_images_tag,
+            opencrvs_tools_chart_path=opencrvs_tools_chart_path
+        ),
+        quiet=True
+    )
+
+    k8s_yaml(job_yaml)
+    k8s_resource(
+        'data-seed',
+        labels=['2.Data-tasks'],
+        auto_init=False
+    )

--- a/tilt/opencrvs.tilt
+++ b/tilt/opencrvs.tilt
@@ -1,0 +1,117 @@
+# Shared OpenCRVS Tilt configuration
+# Load extensions
+load('ext://namespace', 'namespace_create', 'namespace_inject')
+load("./lib.tilt", 
+        "copy_secrets", "data_cleanup", "seed_data")
+include('./common.tilt')
+
+def setup_opencrvs(
+    core_images_tag,
+    countryconfig_image_tag,
+    countryconfig_image_name="opencrvs/ocrvs-countryconfig",
+    dependencies_namespace='opencrvs-deps-dev',
+    opencrvs_namespace='opencrvs-dev',
+    security_enabled=False,
+    monitoring_enabled=False,
+    opencrvs_chart_repo='.'
+):
+    """
+    Common OpenCRVS setup function
+    
+    Args:
+        core_images_tag: OpenCRVS core images tag to use for deployment
+        countryconfig_image_name: Countryconfig image repository (e.g. your DockerHub repository or Farajaland demo repository)
+        countryconfig_image_tag: Countryconfig image tag to use for deployment
+        dependencies_namespace: Kubernetes namespace for dependencies (e.g. MongoDB, MinIO, Elasticsearch)
+        opencrvs_namespace: Kubernetes namespace for OpenCRVS services
+        security_enabled: If true, OpenCRVS and dependencies will be deployed in secure mode with authentication enabled. If false, OpenCRVS and dependencies will be deployed in non-secure mode with default passwords and no authentication.
+        monitoring_enabled: If true, monitoring components like Kibana will be deployed together with dependencies
+        opencrvs_chart_repo: Path to OpenCRVS charts directory (relative)
+    """
+        
+    # Create namespaces
+    namespace_create(dependencies_namespace)
+    namespace_create(opencrvs_namespace)
+    
+    # Select configuration files
+    if security_enabled:
+        print("🔑 Deploying OpenCRVS and Dependencies in secure mode")
+        deps_configuration_file = './tilt/examples/dependencies/values-secure.yaml'
+        opencrvs_configuration_file = './tilt/examples/opencrvs-services/values-secure.yaml'
+    else:
+        print("""🔑 Deploying OpenCRVS and Dependencies in non-secure mode
+        - Minio admin user/password: minioadmin/minioadmin
+        - Postgres admin user/password: postgres/postgres
+        - Authentication for Redis, MongoDB and Elasticsearch is disabled""")
+        deps_configuration_file = './tilt/examples/dependencies/values.yaml'
+        opencrvs_configuration_file = './tilt/examples/opencrvs-services/values.yaml'
+    
+    # Deploy dependencies
+    print("🚀 Deploying dependencies: mongo, minio, elasticsearch...")
+    dependencies_chart_path = '{}/charts/dependencies'.format(opencrvs_chart_repo)
+    k8s_yaml(helm(dependencies_chart_path,
+        namespace=dependencies_namespace,
+        values=[deps_configuration_file],
+        set=["monitoring.enabled={}".format(monitoring_enabled).lower()]
+    ))
+    opencrvs_chart_path = '{}/charts/opencrvs-services'.format(opencrvs_chart_repo)
+    certs_dir = '{opencrvs_chart_path}/certs'.format(opencrvs_chart_path=opencrvs_chart_path)
+    if not os.path.exists("{certs_dir}/tls.crt".format(certs_dir=certs_dir)):
+        local("""
+        mkdir -p {certs_dir}
+        openssl req -x509 -nodes -days 365 \
+        -newkey rsa:2048 \
+        -keyout {certs_dir}/tls.key \
+        -out {certs_dir}/tls.crt \
+        -subj "/CN=local.dev"
+        """.format(certs_dir=certs_dir))
+
+    # Deploy OpenCRVS services
+    print("🚀 Deploying services: auth, events, gateway...")
+    k8s_yaml(
+        helm(opencrvs_chart_path,
+             namespace=opencrvs_namespace,
+             values=[opencrvs_configuration_file],
+             set=[
+                "platform.tag={}".format(core_images_tag),
+                "countryconfig.image.name={}".format(countryconfig_image_name),
+                "countryconfig.image.tag={}".format(countryconfig_image_tag),
+                "data_seed.enabled=false", # Disable data seeding on helm install for tilt
+                "certs.crt_file=certs/tls.crt",
+                "certs.key_file=certs/tls.key"
+             ]
+        )
+    )
+    cleanup_cmd = "./scripts/cleanup.sh"
+
+    if os.name == "nt":
+        cleanup_cmd = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\cleanup.ps1"
+
+    local_resource(
+        name="clean-&-seed",
+        auto_init=False,
+        labels="2.Data-tasks",
+        cmd="./tilt/clear-all-data.sh",
+        allow_parallel=True,
+    )
+    # Add data tasks
+    data_cleanup(
+        opencrvs_namespace,
+        opencrvs_configuration_file,
+        core_images_tag,
+        countryconfig_image_name,
+        countryconfig_image_tag,
+        opencrvs_chart_path
+    )
+
+    seed_data(
+        opencrvs_namespace,
+        opencrvs_configuration_file,
+        core_images_tag,
+        countryconfig_image_name,
+        countryconfig_image_tag,
+        opencrvs_chart_path
+    )
+    
+    if security_enabled:
+        copy_secrets(dependencies_namespace, opencrvs_namespace)


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Related PRs:
- https://github.com/opencrvs/opencrvs-core/pull/12689
- https://github.com/opencrvs/e2e/pull/153
- https://github.com/opencrvs/opencrvs-helm-charts/pull/64

Related issue: https://github.com/opencrvs/opencrvs-core/issues/12679

Goal of this PR is to add Tilt component as default development tool for developers and integrators.

**Testing summary**
- Initial environment setup: 11 minutes
- Existing environment startup: 2 minutes

See details in **Testing** section

## Testing

Following Hardware and software specification was used for testing:
- OS: Kubuntu 26.04 LTS
- KDE: 6.6.4
- CPU: 8 × Intel® Core™ i5-1035G1 CPU @ 1.00GHz
- RAM: 16 ГіБ RAM
- Graphics: Intel® UHD Graphics
- Product name: HP 340S G7 Notebook PC

Internet connectivity speed
<img width="492" height="160" alt="image" src="https://github.com/user-attachments/assets/b80c4d8b-9da8-4538-844a-f51581c48576" />
```
Client: Docker version: 28.5.1
Server: Docker Engine - Community: 28.5.1
minikube version: v1.35.0
tilt version: v0.37.0, built 2026-03-04
```

### Fresh install

Installation steps:

Create minikube cluster (1m)
```
minikube start --cpus=8 --memory=11g --ports=80:30080
```
Start tilt
```
tilt up
```

What tilt will do?
- Pull and start dependencies: 4m
  <img width="471" height="607" alt="image" src="https://github.com/user-attachments/assets/1d7006eb-e625-4f55-8355-8a04eedf6447" />
  <img width="529" height="229" alt="image" src="https://github.com/user-attachments/assets/29f0917c-4d2e-4a6e-a0c2-fde14a78647b" />

- Run pre-deploy hooks, execution order is setup to make sure database migrations will not run before database startup: 2m
  <img width="1101" height="576" alt="image" src="https://github.com/user-attachments/assets/8f2086cd-0ca2-41cc-87c9-e86d981f294d" />
- Start OpenCRVS core containers: 5m
   <img width="1011" height="613" alt="image" src="https://github.com/user-attachments/assets/c968f6e9-03ad-4eef-bc70-1db2878a4f93" />
- Build countryconfig image:
   <img width="1630" height="866" alt="image" src="https://github.com/user-attachments/assets/7c37ed3b-c10f-4e5a-8dbf-d5a2f99e1202" />
- Screenshot shows the progress over time: 
   <img width="907" height="651" alt="image" src="https://github.com/user-attachments/assets/6e615e91-1906-4b9a-8258-42c1a26ed9a3" />
   <img width="1761" height="788" alt="image" src="https://github.com/user-attachments/assets/7289238e-ff81-47bf-864b-fa83f8340baa" />
- Data seed execution: 2m
   <img width="1855" height="855" alt="image" src="https://github.com/user-attachments/assets/ccec6bef-ec2b-42d5-97a8-ad8006b619dd" />


**Total environment startup time: 10m**

### Startup on existing minikube cluster

This scenario describes daily work, when developer comes to workplace and turns on laptop

Startup time: 2m

Preconditions:
- Minikube cluster with OpenCRVS was already set up and running
- All source code is already present
- All images are inside minikube cluster
<img width="777" height="380" alt="image" src="https://github.com/user-attachments/assets/22b86a29-0517-4bd6-ae91-6b68306291b4" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
