### PR TITLE
fix: Improve compatibility for tilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ minikube
 
 > [!NOTE]
 > Other local Kubernetes engines may also work, for example:
+> - Docker Desktop
 > - OrbStack
 > - kind
 > - k3d

--- a/Tiltfile
+++ b/Tiltfile
@@ -8,7 +8,7 @@
 core_images_tag = os.getenv("OPENCRVS_CORE_IMAGE_TAG", "v2.0.0-beta")
 
 # FIXME: Put release version
-core_ref = os.getenv("OPENCRVS_CORE_REF", "add-helm-charts")
+core_ref = os.getenv("OPENCRVS_CORE_REF", "release-v2.0.0")
 
 # Build countryconfig image in local registry (use any name and tag you want)
 countryconfig_image_name="opencrvs/ocrvs-countryconfig"

--- a/tilt/examples/traefik/values.yaml
+++ b/tilt/examples/traefik/values.yaml
@@ -28,7 +28,6 @@ service:
 ports:
   web:
     port: 8000
-    hostPort: 80
     protocol: TCP
     nodePort: 30080
 


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Goal of this PR is to improve compatibility between different Kubernetes distributions.

Tested versions:
| Distribution | Platform |
|---|---|
| Minikube v1.37.0 with Docker engine 28.4.0 | MacOS 26.5 (apple silicon) |
| Minikube v1.35.0 with Docker engine 29.5.2 | Ubuntu 26.04 |
| OrbStack 2.1.3 | MacOS 26.5 (apple silicon) |
| Docker Desktop with kubeadm Kubernetes cluster 4.47.0 | MacOS 26.5 (apple silicon) |

OpenCRVS version: v2.0.0-beta


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
