### PR TITLE
fix: Log filtering and search - not working in Kibana

### DIFF
--- a/infrastructure/monitoring/kibana/setup-config.sh
+++ b/infrastructure/monitoring/kibana/setup-config.sh
@@ -96,3 +96,39 @@ curl --connect-timeout 60 -u elastic:$ELASTICSEARCH_SUPERUSER_PASSWORD "$kibana_
   curl --connect-timeout 60 -X POST -H 'kbn-xsrf: true' -u elastic:$ELASTICSEARCH_SUPERUSER_PASSWORD "http://kibana:5601/api/alerting/rule/$id/_disable"
   curl --connect-timeout 60 -X POST -H 'kbn-xsrf: true' -u elastic:$ELASTICSEARCH_SUPERUSER_PASSWORD "http://kibana:5601/api/alerting/rule/$id/_enable"
 done
+
+# TODO: This logic needs to be rewritten:
+# tested manually in elasticsearch container on Farajaland DEV
+echo "Setting default data view to ecs-*"
+
+# 1. Create data view if it doesn't exist:
+# Get data view id for ecs-*
+DATA_VIEW_ID=$(curl -s \
+  -u elastic:$ELASTICSEARCH_SUPERUSER_PASSWORD \
+  "${KIBANA_URL}/api/data_views" \
+  | jq -r '.data_view[] | select(.title=="ecs-*") | .id')
+# Check existance:
+if [ -z "$DATA_VIEW_ID" ]; then
+  echo "Creating data view ecs-*"
+  # Create dataview and get id:
+  DATA_VIEW_ID=$(curl -s \
+    -u elastic:$ELASTICSEARCH_SUPERUSER_PASSWORD \
+    -X POST "${KIBANA_URL}/api/data_views/data_view" \
+    -H 'kbn-xsrf: true' \
+    -H 'Content-Type: application/json' \
+    -d '{
+      "data_view": {
+        "title": "ecs-*",
+        "name": "OpenCRVS Logs"
+      }
+    }' | jq -r '.data_view.id')
+    # Set as default data view:
+    curl -s \
+      -u elastic:$ELASTICSEARCH_SUPERUSER_PASSWORD \
+      -X POST "${KIBANA_URL}/api/data_views/default" \
+      -H 'kbn-xsrf: true' \
+      -H 'Content-Type: application/json' \
+      -d "{\"data_view_id\":\"${DATA_VIEW_ID}\"}"
+fi
+
+echo "Data view id: $DATA_VIEW_ID"


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Related PR for K8s: https://github.com/opencrvs/opencrvs-core/pull/12855

Related issue: https://github.com/opencrvs/opencrvs-core/issues/11628

NEXT STEP: Merger into release/2.0.0

## Testing


**Run locally on Farajaland DEV:**

1. Create file /opt/opencrvs/infrastructure/monitoring/kibana/test.sh
2. Add environment variables:
    ```
    ELASTICSEARCH_SUPERUSER_PASSWORD=<...>
    HOST=kibana.<Farajaland DEV hostname>
    ```
3. Run script: 
    ```
    cd /opt/opencrvs/infrastructure/monitoring/kibana && bash ./test.sh 
    ```
    Output
    ```
    ...
    Creating data view ecs-*
    Setting default data view to ecs-* for Logs Explorer
    {"acknowledged":true}
    Setting default index to ecs-* for Discover
    {"settings":{"buildNum":{"userValue":80032},"isDefaultIndexMigrated":{"userValue":true},"defaultIndex":{"userValue":"4ef28fd9-da70-46b9-8b7c-2a6691cfca38"},"observability:logSources":{"userValue":["filebeat-*","ecs-*"]}}}
    Setup Observability indices
    {"settings":{"buildNum":{"userValue":80032},"isDefaultIndexMigrated":    {"userValue":true},"defaultIndex":{"userValue":"4ef28fd9-da70-46b9-8b7c-2a6691cfca38"},"observability:logSources":{"userValue":["filebeat-*","ecs-*"]}}}
    OpenCRVS Logs Data view id: 4ef28fd9-da70-46b9-8b7c-2a6691cfca38
    ```
Verify results on UI: `https://kibana.<...>/app/management/kibana/dataViews#/`

Data View exists and is set as Default:
<img width="972" height="477" alt="image" src="https://github.com/user-attachments/assets/08648beb-14e4-4ac6-8678-60ce4a0c93c6" />

Logs are showing in Discover:
<img width="1224" height="862" alt="image" src="https://github.com/user-attachments/assets/4c51ec4c-3015-4f49-9831-dc1d1488f816" />

Logs are showing in Log Explorer:
<img width="1224" height="865" alt="image" src="https://github.com/user-attachments/assets/8fd27d17-5be5-4ae9-a20f-3d14ae6a1ccc" />


**Re-run script**

In this scenario data view already exists
Run script: 
```
cd /opt/opencrvs/infrastructure/monitoring/kibana && bash ./test.sh 
```
Output:
```
OpenCRVS Logs Data view id: 4ef28fd9-da70-46b9-8b7c-2a6691cfca38
```


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
