### PR TITLE
fix: make previous number of birth integer only

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/toolkit": "2.0.0-rc.f181fff",
+    "@opencrvs/toolkit": "2.0.0-rc.f20384d",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",
     "@types/fhir": "^0.0.30",

--- a/src/events/birth/forms/pages/mother.ts
+++ b/src/events/birth/forms/pages/mother.ts
@@ -479,6 +479,7 @@ export const mother = defineFormPage({
         }
       ],
       configuration: {
+        integer: true,
         min: 0
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,10 +814,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opencrvs/toolkit@2.0.0-rc.f181fff":
-  version "2.0.0-rc.f181fff"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-2.0.0-rc.f181fff.tgz#aa7f8058e47d3195c5eb2c11d2c287bdf920556c"
-  integrity sha512-mmZkDX0/Y38eG7gqDZlH668HD7XPp3NqEtQkNe5VByWl2zlWrTe1oY5A3PsH4aQCi1sVR1CnY5ezrpzsZlwZsg==
+"@opencrvs/toolkit@2.0.0-rc.f20384d":
+  version "2.0.0-rc.f20384d"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-2.0.0-rc.f20384d.tgz#21506c8f7ae5ea06bd12c5f204f65642ee66b925"
+  integrity sha512-/Noc2XKeTPS4um0HRd2lCV3NmTPukIC6DOO4KAhHiXXyM5lnF0lRa95ACGTdT6N8Nr8dD4R5rvt/d091zF0f/g==
   dependencies:
     "@trpc/client" "11.4.3"
     "@trpc/server" "^11.8.0"


### PR DESCRIPTION
fixes: https://github.com/opencrvs/opencrvs-core/issues/12989

> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
