### PR TITLE
fix: add new translations for unarchive in client

### DIFF
--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -102,6 +102,7 @@ buttons.settings,Menu item settings,Settings,Paramètres
 buttons.start,Label of start button,Start,Démarrer
 buttons.status,Label of status button,Status,Statut
 buttons.submitCorrectionRequest,Submit correction request button text,Submit correction request,Soumettre une demande de correction
+buttons.unarchive,Unarchive button text,Unarchive,Désarchiver
 buttons.unassign,Unassign button label,Unassign,Désaffecter
 buttons.update,The title of update button for draft declaration,Update,Mise à jour
 buttons.upload,Upload buttton,Upload,Télécharger
@@ -684,6 +685,7 @@ event.birth.action.register.supportingCopy,The description for registration acti
 event.birth.action.registrar-general-feedback.label,This is shown when the registrar general feedback can be triggered from the action from,Registrar general feedback,Retour du registraire général
 event.birth.action.reject.label,This is the label for the reject action,Reject,Rejeter
 event.birth.action.request-correction.label,This is shown as the action name anywhere the user can trigger the action from,Correct,Corriger
+event.birth.action.unarchive.label,Label for unarchive record button in dropdown menu,Unarchive,Désarchiver
 event.birth.custom.action.approve.field.collector.label,Label for collector field,Collector,le collectionneur
 event.birth.custom.action.approve.field.notes.label,This is the label for the field for a custom action,Comments,Commentaires
 event.birth.custom.action.validate-declaration.audit-history-label,The label to show in audit history for the validate action,Validated,Validé


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
