### PR TITLE
fix: apply latest post-release fixes to Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -5,10 +5,10 @@
 
 # OpenCRVS core images tag:
 # For releases it's ok to keeps same as branch_or_tag
-core_images_tag = os.getenv("OPENCRVS_CORE_IMAGE_TAG", "v2.0.0-beta")
+core_images_tag = os.getenv("OPENCRVS_CORE_IMAGE_TAG", "v2.0.0")
 
 # FIXME: Put release version
-core_ref = os.getenv("OPENCRVS_CORE_REF", "release-v2.0.0")
+core_ref = os.getenv("OPENCRVS_CORE_REF", "release/2.0.0")
 
 # Build countryconfig image in local registry (use any name and tag you want)
 countryconfig_image_name="opencrvs/ocrvs-countryconfig"

--- a/tilt/common.tilt
+++ b/tilt/common.tilt
@@ -18,9 +18,16 @@ traefik_tilt_label = '5.Traefik'
 # Install Traefik GW
 helm_repo('traefik-repo', 'https://traefik.github.io/charts', labels=[traefik_tilt_label])
 helm_resource(
-  'traefik', 'traefik-repo/traefik', namespace='traefik', resource_deps=['traefik-repo'],
-  flags=['--values=./examples/traefik/values.yaml'])
-
+    'traefik',
+    'traefik-repo/traefik',
+    namespace='traefik',
+    resource_deps=['traefik-repo'],
+    flags=[
+        '--version=39.0.0',
+        '--values=./examples/traefik/values.yaml',
+        '--create-namespace',
+    ],
+)
 # OpenCRVS application has traefik CRDs IngressRoute
 # and Middleware, so we need to add traefik as dependency
 # to all workloads that use them
@@ -91,7 +98,6 @@ opensrvs_services = [
   'events',
   'gateway',
   'login',
-  'user-mgnt'
 ]
 
 opensrvs_postdeploy_jobs = [

--- a/tilt/examples/traefik/values.yaml
+++ b/tilt/examples/traefik/values.yaml
@@ -23,12 +23,10 @@ providers:
 service:
   enabled: true
   single: false
-  type: NodePort
 
 ports:
   web:
     port: 8000
     protocol: TCP
-    nodePort: 30080
 
 tlsStore: {}


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Fix tilt after OpenCRVS v2.0.0 release:
- Branch release strategy changed from `release-vX.Y.Z` to `release/X.Y.Z`
- Fix image tag to stable release
- Drop user-mgnt service
- Stick Traefik helm chart to fixed release version

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
