### PR TITLE
fix: Incompatibility issues between beta and stable release

### DIFF
--- a/tilt/examples/opencrvs-services/values.yaml
+++ b/tilt/examples/opencrvs-services/values.yaml
@@ -9,11 +9,11 @@ credentials:
 
 # OpenCRVS core image tag:
 platform:
-  tag: v2.0.0-beta
+  tag: v2.0.0
 
 countryconfig:
   image:
-    tag: v1.9.11
+    tag: v2.0.0
 
 # Horizontal Pod Autoscaler (HPA) configuration:
 # Disabled by default for local environment.

--- a/tilt/lib.tilt
+++ b/tilt/lib.tilt
@@ -33,7 +33,7 @@ def data_cleanup(
             helm template {opencrvs_tools_chart_path} \
                 --namespace {opencrvs_namespace} \
                 -f {opencrvs_configuration_file} \
-                --set image.tag={core_images_tag} \
+                --set platform.tag={core_images_tag} \
                 --set data_cleanup.enabled=true \
                 --set countryconfig.image.name={countryconfig_image_name} \
                 --set countryconfig.image.tag={countryconfig_image_tag} \
@@ -66,7 +66,7 @@ def seed_data(
 ):
     job_yaml = local("""
       helm template -f {opencrvs_configuration_file} \
-        --set image.tag={core_images_tag} \
+        --set platform.tag={core_images_tag} \
         --set data_seed.enabled=true -s templates/data-seed-job.yaml --namespace {opencrvs_namespace} {opencrvs_tools_chart_path}
       """.format(
             opencrvs_namespace=opencrvs_namespace,


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Fix tilt functions (seed_data, cleanup_data) to use new helm values passed as arguments.

<img width="1384" height="830" alt="image" src="https://github.com/user-attachments/assets/3e90780b-bcec-458f-bd81-cc8b111b5f58" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
