### PR TITLE
[OCRVS-13246] Security fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.9.16 Release Candidate
 
+### Improvements
+
+- Traefik now negotiates only AEAD cipher suites (AES-GCM and ChaCha20-Poly1305) on TLS 1.2, via a new `infrastructure/traefik/dynamic.yml`. Previously no TLS options were configured at all, so Traefik fell back to Go's defaults, which still offer `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA` and `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA` — CBC suites with HMAC-SHA-1, flagged by a national vulnerability scan and disallowed by ANSSI-BP-035. TLS 1.3 is unaffected. [#13246](https://github.com/opencrvs/opencrvs-core/issues/13246)
+
+- The client and login apps now receive an explicit list of allowed Content-Security-Policy sources instead of the `*.<domain>` wildcard, so neither app trusts unrelated subdomains such as Kibana, the MinIO console or webhooks. Each app gets only what it uses: the login app is limited to the gateway, config and country config origins. The `CONTENT_SECURITY_POLICY_WILDCARD` environment variable is no longer used and has been removed from `setup-environment.ts` — the values are now derived from the deployment hostname directly in the compose file. [#13246](https://github.com/opencrvs/opencrvs-core/issues/13246)
+
+  **Upgrade note:** if you have customised `docker-compose.deploy.yml` and still reference `${CONTENT_SECURITY_POLICY_WILDCARD}`, either keep setting that variable yourself or adopt the explicit lists. Add any extra origin your country configuration loads in the browser (for example a custom font or asset host) to the relevant list, or it will be blocked.
+
 ## 1.9.15 Release Candidate
 
 ## 1.9.14 Release Candidate

--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -22,11 +22,14 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /data/traefik/acme.json:/acme.json
+      # TLS options (cipher suites) cannot be expressed as Docker labels
+      - '/opt/opencrvs/infrastructure/traefik/dynamic.yml:/etc/traefik/dynamic.yml'
     command:
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
       - --providers.docker
       - --providers.docker.swarmMode=true
+      - --providers.file.filename=/etc/traefik/dynamic.yml
       - --api.dashboard=true
       - --api.insecure=true
       - --log.level=WARNING
@@ -502,7 +505,17 @@ services:
     environment:
       - DECLARED_DECLARATION_SEARCH_QUERY_COUNT=100
       - COUNTRY_CONFIG_URL=https://countryconfig.{{hostname}}
-      - CONTENT_SECURITY_POLICY_WILDCARD=${CONTENT_SECURITY_POLICY_WILDCARD}
+      # Extra sources for the client's Content-Security-Policy. Listed explicitly
+      # rather than as *.{{hostname}}, so a scan does not report an over-broad
+      # source and no unrelated subdomain (kibana, minio-console, webhooks) is
+      # trusted by the app. Each entry is here for a reason:
+      #   gateway       - API and auth calls
+      #   config        - CONFIG_API_URL
+      #   countryconfig - handlebars.js, content, images
+      #   minio         - document upload and download
+      #   metabase      - dashboards, which the client embeds in an iframe
+      # See https://github.com/opencrvs/opencrvs-core/issues/13246
+      - CONTENT_SECURITY_POLICY_WILDCARD=https://gateway.{{hostname}} https://config.{{hostname}} https://countryconfig.{{hostname}} https://minio.{{hostname}} https://metabase.{{hostname}}
       - MINIO_URL=https://minio.{{hostname}}
     deploy:
       labels:
@@ -602,7 +615,14 @@ services:
   login:
     environment:
       - COUNTRY_CONFIG_URL=https://countryconfig.{{hostname}}
-      - CONTENT_SECURITY_POLICY_WILDCARD=${CONTENT_SECURITY_POLICY_WILDCARD}
+      # Extra sources for the login app's Content-Security-Policy. login.{{hostname}}
+      # is the host ANSSI scanned, so this list is deliberately the minimum the app
+      # needs — it loads no third-party scripts and embeds nothing:
+      #   gateway       - AUTH_API_URL, at gateway.{{hostname}}/auth/
+      #   config        - CONFIG_API_URL, for /publicConfig
+      #   countryconfig - /content/login, for country branding and copy
+      # See https://github.com/opencrvs/opencrvs-core/issues/13246
+      - CONTENT_SECURITY_POLICY_WILDCARD=https://gateway.{{hostname}} https://config.{{hostname}} https://countryconfig.{{hostname}}
     deploy:
       labels:
         - 'traefik.enable=true'

--- a/infrastructure/environments/setup-environment.ts
+++ b/infrastructure/environments/setup-environment.ts
@@ -641,13 +641,6 @@ const derivedVariables = [
     scope: 'ENVIRONMENT'
   },
   {
-    name: 'CONTENT_SECURITY_POLICY_WILDCARD',
-    valueLabel: 'CONTENT_SECURITY_POLICY_WILDCARD',
-    valueType: 'VARIABLE',
-    type: 'disabled',
-    scope: 'ENVIRONMENT'
-  },
-  {
     name: 'CLIENT_APP_URL',
     valueLabel: 'CLIENT_APP_URL',
     valueType: 'VARIABLE',
@@ -1377,22 +1370,6 @@ const SPECIAL_NON_APPLICATION_ENVIRONMENTS = ['jump', 'backup']
       ),
       didExist: findExistingValue(
         'GATEWAY_HOST',
-        'VARIABLE',
-        'ENVIRONMENT',
-        existingValues
-      ),
-      scope: 'ENVIRONMENT' as const
-    },
-    {
-      type: 'VARIABLE' as const,
-      name: 'CONTENT_SECURITY_POLICY_WILDCARD',
-      value: answerOrExisting(
-        allAnswers.domain,
-        findExistingValue('DOMAIN', 'VARIABLE', 'ENVIRONMENT', existingValues),
-        (val) => `*.${val}`
-      ),
-      didExist: findExistingValue(
-        'CONTENT_SECURITY_POLICY_WILDCARD',
         'VARIABLE',
         'ENVIRONMENT',
         existingValues

--- a/infrastructure/traefik/dynamic.yml
+++ b/infrastructure/traefik/dynamic.yml
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+
+# Traefik dynamic configuration. TLS options cannot be set through Docker labels,
+# so they are provided here via the file provider (see --providers.file.filename
+# on the traefik service in docker-compose.deploy.yml).
+#
+# Without this, Traefik falls back to Go's default TLS 1.2 cipher list, which
+# includes CBC suites with HMAC-SHA-1 — TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA and
+# TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA. Burkina Faso's ANSSI scan flagged them
+# (observation O4), and ANSSI-BP-035 asks for AEAD suites only.
+# See https://github.com/opencrvs/opencrvs-core/issues/13246
+#
+# The option set named "default" applies to every router that does not name its
+# own, so this covers all OpenCRVS routers without touching their labels.
+tls:
+  options:
+    default:
+      minVersion: VersionTLS12
+      # AEAD only: AES-GCM and ChaCha20-Poly1305. TLS 1.3 suites are not
+      # configurable in Go and stay enabled regardless of this list.
+      cipherSuites:
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256


### PR DESCRIPTION
### Why

The infrastructure half of [opencrvs-core#13246](https://github.com/opencrvs/opencrvs-core/issues/13246) — Burkina Faso's ANSSI scan of VENEEM. Two observations remained open; the core PR covers the CSP directives, this one covers what only the deployment can fix.

Two corrections to the ticket's assumptions came out of implementing it:

- **O4 is not certificate-related and is not outside our control.** No `tls.options` / `cipherSuites` is defined anywhere in `infrastructure/`, so Traefik v2.11 falls back to Go's default TLS 1.2 cipher list. I reproduced this locally: with no TLS options, `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA` and `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA` are both accepted — exactly the two suites ANSSI flagged. It is a Traefik config gap, and it affects every OpenCRVS deployment, not just Burkina Faso.
- **The over-broad CSP sources ANSSI flagged are generated by us.** `setup-environment.ts` derived `CONTENT_SECURITY_POLICY_WILDCARD` as `*.${DOMAIN}`, which trusts every subdomain — including `kibana`, `minio-console` and `webhooks`.

### What changes

- **New `infrastructure/traefik/dynamic.yml`** — `tls.options.default` with `minVersion: VersionTLS12` and an AEAD-only cipher list (AES-GCM + ChaCha20-Poly1305), per ANSSI-BP-035. Traefik applies the option set named `default` to every router that doesn't name its own, so no router labels change. Wired in with a volume mount plus `--providers.file.filename=/etc/traefik/dynamic.yml`, since TLS options cannot be expressed as Docker labels. TLS 1.3 suites are not configurable in Go and stay enabled.
- **Explicit CSP sources per app** in `docker-compose.deploy.yml`, replacing `*.{{hostname}}`. Derived inline from `{{hostname}}` — already the established pattern in this file (`COUNTRY_CONFIG_URL`, `MINIO_URL`) — so no new environment variables and no core change:
  - client → `gateway`, `config`, `countryconfig`, `minio`, `metabase` (dashboards are embedded in an iframe, and the client CSP has no `frame-src`, so it falls back to `default-src`)
  - login → `gateway`, `config`, `countryconfig` only. This is the host ANSSI scanned, so it gets the minimum: `/publicConfig` from config, `AUTH_API_URL` on the gateway, and `/content/login` from country config.
- **`CONTENT_SECURITY_POLICY_WILDCARD` removed from `setup-environment.ts`** — nothing reads it now. The compose validator only requires variables that appear as `${VAR}`, so this does not make any deploy fail.

The lists were derived from `client-config.prod.js` / `login-config.prod.js` and cross-checked against every `window.config.*` key the client reads. `img-src` is untouched and still allows all `https:`, so images (including `ui-avatars.com` avatars) are unaffected. Sentry's `connect-src` was already not covered by the old wildcard — unchanged, not a regression introduced here.

### How to test

- **Cipher suites — the actual ANSSI check.** Serve the file with a throwaway cert and probe:
  ```sh
  docker run -d --name tlsprobe -p 8443:443 \
    -v "$PWD/infrastructure/traefik/dynamic.yml:/etc/traefik/conf.d/options.yml:ro" \
    -v "$PWD/certs:/certs:ro" traefik:v2.11 \
    --entrypoints.websecure.address=:443 --providers.file.directory=/etc/traefik/conf.d
  # must fail:
  openssl s_client -connect localhost:8443 -tls1_2 -cipher ECDHE-RSA-AES128-SHA
  # must succeed:
  openssl s_client -connect localhost:8443 -tls1_2 -cipher ECDHE-RSA-AES128-GCM-SHA256
  openssl s_client -connect localhost:8443 -tls1_3
  ```
  Verified locally, including a baseline run with no TLS options to confirm the CBC suites *were* accepted beforehand.
- After deploying, re-scan with `testssl.sh` or SSL Labs and confirm no CBC/SHA-1 suites remain on TLS 1.2, and that the site still loads in supported browsers.
- **Exercise both apps on a deployed environment with devtools open** and confirm no CSP violations: sign in (login → gateway → config → country config content), then in the client open a record, upload and download a document (minio), and open each dashboard (metabase iframe). This is the main risk in this PR — a missing origin shows up as a blocked request, not a build failure.
- `npx tsc --noEmit` passes; `eslint` on `setup-environment.ts` reports the same 21 pre-existing problems as before the change (none introduced).

### Follow-ups

- **`opencrvs-farajaland` needs the same two changes** — it carries its own copies of `docker-compose.deploy.yml` (wildcard on lines 506 and 616) and `setup-environment.ts`, and likewise has no TLS options configured.
- If a country configuration loads anything else cross-origin in the browser (custom fonts, an asset CDN), that origin now has to be added to the relevant list explicitly.